### PR TITLE
Update example fetch-renderer-lib command to account for local module testing

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -35,10 +35,10 @@ Update the frontend service's `Makefile` with the following new commands so that
 ```Makefile
 LOCAL_DP_RENDERER_IN_USE = $(shell grep -c "\"github.com/ONSdigital/dp-renderer\" =" go.mod)
 
-.PHONY: fetch-renderer-lib
+.PHONY: fetch-dp-renderer
 fetch-renderer-lib:
 ifeq ($(LOCAL_DP_RENDERER_IN_USE), 1)
- $(eval CORE_ASSETS_PATH = $(shell grep -w "\"github.com/ONSdigital/dp-renderer\" =>" go.mod | awk -F '=> ' '{print $$2}'))
+ $(eval CORE_ASSETS_PATH = $(shell grep -w "\"github.com/ONSdigital/dp-renderer\" =>" go.mod | awk -F '=> ' '{print $$2}' | tr -d '"'))
 else
  $(eval APP_RENDERER_VERSION=$(shell grep "github.com/ONSdigital/dp-renderer" go.mod | cut -d ' ' -f2 ))
  $(eval CORE_ASSETS_PATH = $(shell go get github.com/ONSdigital/dp-renderer@$(APP_RENDERER_VERSION) && go list -f '{{.Dir}}' -m github.com/ONSdigital/dp-renderer))

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -33,13 +33,15 @@ For `dp-renderer` to work correctly once the assets have been migrated over, we 
 Update the frontend service's `Makefile` with the following new commands so that `go-bindata` will generate this file:
 
 ```Makefile
-.PHONY: get-renderer-version
-get-renderer-version:
- $(eval APP_RENDERER_VERSION=$(shell grep "github.com/ONSdigital/dp-renderer" go.mod | cut -d ' ' -f2 ))
-
 .PHONY: fetch-renderer-lib
-fetch-renderer-lib: get-renderer-version
+fetch-renderer-lib:
+ifeq ($(LOCAL_DP_RENDERER_IN_USE), 1)
+ $(eval CORE_ASSETS_PATH = $(shell grep -w "\"github.com/ONSdigital/dp-renderer\" =>" go.mod | awk -F '=> ' '{print $$2}'))
+else
+ $(eval APP_RENDERER_VERSION=$(shell grep "github.com/ONSdigital/dp-renderer" go.mod | cut -d ' ' -f2 ))
  $(eval CORE_ASSETS_PATH = $(shell go get github.com/ONSdigital/dp-renderer@$(APP_RENDERER_VERSION) && go list -f '{{.Dir}}' -m github.com/ONSdigital/dp-renderer))
+endif
+
 
 .PHONY: generate-debug
 generate-debug: fetch-renderer-lib

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -33,6 +33,8 @@ For `dp-renderer` to work correctly once the assets have been migrated over, we 
 Update the frontend service's `Makefile` with the following new commands so that `go-bindata` will generate this file:
 
 ```Makefile
+LOCAL_DP_RENDERER_IN_USE = $(shell grep -c "\"github.com/ONSdigital/dp-renderer\" =" go.mod)
+
 .PHONY: fetch-renderer-lib
 fetch-renderer-lib:
 ifeq ($(LOCAL_DP_RENDERER_IN_USE), 1)


### PR DESCRIPTION
### What

- Updated migration doc to include a tweaked version of the `fetch-renderer-lib` Make command, which now checks to see whether there is a local version of `dp-renderer` present in the `go.mod` file. If there is, it will not run `go get` and instead use the local version instead

### How to review

- Sense check the change

### Who can review

- Anyone
