### PR TITLE
ONS Design System feature toggle

### DIFF
--- a/assets/templates/main.tmpl
+++ b/assets/templates/main.tmpl
@@ -7,7 +7,8 @@
       {{ else if .Error -}}
         {{if .Error.Title }}{{ .Error.Title }}
         {{- end }}
-      {{- end}} - {{ localise "OfficeForNationalStatistics" .Language 1 }}</title>
+      {{- end}} - {{ localise "OfficeForNationalStatistics" .Language 1 }}
+    </title>
     {{if eq .Metadata.Title "Home"}}<meta name="description" content="{{ localise "HomepageDescription" .Language 1 }}">
     {{else}}<meta name="description" content="{{ .Metadata.Description}}">{{end}}
     <meta charset="utf-8"/>
@@ -79,15 +80,15 @@
 
         {{ template "partials/footer" . }}
 
-  {{ if .FeatureFlags.ONSDesignSystemVersion }}
+    {{ if .FeatureFlags.ONSDesignSystemVersion }}
+        </div>
       </div>
-    </div>
-    <script>
-      var ONS_assets_base_URL = 'https://cdn.ons.gov.uk/sdc/design-system/{{.FeatureFlags.ONSDesignSystemVersion}}/';
-    </script>
-    <script src="https://cdn.ons.gov.uk/sdc/design-system/{{.FeatureFlags.ONSDesignSystemVersion}}/scripts/main.js"></script>
-  {{end}}
-  <script type="text/javascript" src="{{.PatternLibraryAssetsPath}}/js/main.js"></script>
-  <script type="text/javascript" src="/js/app.js"></script>
-</body>
+      <script>
+        var ONS_assets_base_URL = 'https://cdn.ons.gov.uk/sdc/design-system/{{.FeatureFlags.ONSDesignSystemVersion}}/';
+      </script>
+      <script src="https://cdn.ons.gov.uk/sdc/design-system/{{.FeatureFlags.ONSDesignSystemVersion}}/scripts/main.js"></script>
+    {{end}}
+    <script defer src="{{.PatternLibraryAssetsPath}}/js/main.js"></script>
+    <script defer src="/js/app.js"></script>
+  </body>
 </html>

--- a/assets/templates/main.tmpl
+++ b/assets/templates/main.tmpl
@@ -1,19 +1,29 @@
 <!DOCTYPE html>
 <html lang="{{if .Language }}{{ .Language }}{{ else }}en{{ end }}" xml:lang="{{ if .Language }}{{ .Language }}{{ else }}en{{ end }}">
-<head>
+  <head>
 
-    <title>{{ if .Metadata.Title -}}{{ .Metadata.Title }}
-      {{ else if .Error -}}{{if .Error.Title }}{{ .Error.Title }}{{- end }}
+    <title>
+      {{ if .Metadata.Title -}}{{ .Metadata.Title }}
+      {{ else if .Error -}}
+        {{if .Error.Title }}{{ .Error.Title }}
+        {{- end }}
       {{- end}} - {{ localise "OfficeForNationalStatistics" .Language 1 }}</title>
-    {{if eq .Metadata.Title "Home"}}<meta name="description" content="{{ localise "HomepageDescription" .Language 1 }}">{{else}}<meta name="description" content="{{ .Metadata.Description}}">{{end}}
+    {{if eq .Metadata.Title "Home"}}<meta name="description" content="{{ localise "HomepageDescription" .Language 1 }}">
+    {{else}}<meta name="description" content="{{ .Metadata.Description}}">{{end}}
     <meta charset="utf-8"/>
     <meta content="width=device-width,initial-scale=1.0,user-scalable=1" name="viewport">
     <meta name="format-detection" content="telephone=no">
     <meta name="theme-color" content="#58595B">
     <meta name="apple-mobile-web-app-status-bar-style" content="#58595B">
     {{ if .Metadata.ServiceName }}<meta name="ons:service" content="{{ .Metadata.ServiceName}}">{{ end }}
+
+    {{ if .FeatureFlags.ONSDesignSystemVersion }}
+      <link rel="stylesheet" href="https://cdn.ons.gov.uk/sdc/design-system/{{.FeatureFlags.ONSDesignSystemVersion}}/css/main.css">
+    {{ end }}
     <link rel="stylesheet" href="{{.PatternLibraryAssetsPath}}/css/main.css">
-    {{ if .HasJSONLD -}}{{ template "partials/json-ld/base" . }}{{- end }}
+
+    {{ if .HasJSONLD -}}{{ template "partials/json-ld/base" . }}
+    {{- end }}
 
     {{if eq .Metadata.Title "Feedback"}}
       <link rel="canonical" href={{ concatenateStrings "https://www." .SiteDomain "/feedback" }}>
@@ -22,33 +32,62 @@
     {{ template "partials/gtm-data-layer" . }}
 
     <!-- Google Tag Manager -->
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-            new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-            j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-            'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-MBCBVQS');</script>
+    <script>
+      (function (w, d, s, l, i) {
+        w[l] = w[l] || [];
+        w[l].push({'gtm.start': new Date().getTime(), event: 'gtm.js'});
+        var f = d.getElementsByTagName(s)[0],
+          j = d.createElement(s),
+          dl = l != 'dataLayer'
+            ? '&l=' + l
+            : '';
+        j.async = true;
+        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+        f
+          .parentNode
+          .insertBefore(j, f);
+      })(window, document, 'script', 'dataLayer', 'GTM-MBCBVQS');
+    </script>
     <!-- End Google Tag Manager -->
-</head>
-<body class="{{ .Type }}">
-<script>document.body.className = ((document.body.className) ? document.body.className + ' js' : 'js');</script>
-  <!-- Google Tag Manager (noscript) -->
-  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MBCBVQS"
-                    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-  <!-- End Google Tag Manager (noscript) -->
-    {{ if (ne .FeatureFlags.HideCookieBanner true)}}
-      {{ template "partials/banners/cookies" . }}
-    {{ end }}
+  </head>
+  <body class="{{ .Type }}">
+    <script>
+      document.body.className = (
+        (document.body.className)
+        ? document.body.className + ' js js-enabled'
+        : 'js js-enabled');
+    </script>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript>
+      <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MBCBVQS"
+                    height="0" width="0" style="display:none;visibility:hidden"></iframe>
+    </noscript>
+    <!-- End Google Tag Manager (noscript) -->
+    {{ if .FeatureFlags.ONSDesignSystemVersion }}
+      <div class="page">
+        <div class="page__content">
+    {{end}}
+        {{ if (ne .FeatureFlags.HideCookieBanner true)}}
+          {{ template "partials/banners/cookies" . }}
+        {{ end }}
 
-    {{ template "partials/header" . }}
+        {{ template "partials/header" . }}
 
-    <main id="main" role="main" tabindex="-1">
-      {{yield}}
-    </main>
+        <main id="main" role="main" tabindex="-1">
+          {{yield}}
+        </main>
 
-    {{ template "partials/footer" . }}
+        {{ template "partials/footer" . }}
 
-      {{/* TODO - update on live build to use two JS files, not a single one */}}
-    <script type="text/javascript" src="{{.PatternLibraryAssetsPath}}/js/main.js"></script>
-    <script type="text/javascript" src="/js/app.js"></script>
+  {{ if .FeatureFlags.ONSDesignSystemVersion }}
+      </div>
+    </div>
+    <script>
+      var ONS_assets_base_URL = 'https://cdn.ons.gov.uk/sdc/design-system/{{.FeatureFlags.ONSDesignSystemVersion}}/';
+    </script>
+    <script src="https://cdn.ons.gov.uk/sdc/design-system/{{.FeatureFlags.ONSDesignSystemVersion}}/scripts/main.js"></script>
+  {{end}}
+  <script type="text/javascript" src="{{.PatternLibraryAssetsPath}}/js/main.js"></script>
+  <script type="text/javascript" src="/js/app.js"></script>
 </body>
 </html>

--- a/model/page.go
+++ b/model/page.go
@@ -24,6 +24,7 @@ type Page struct {
 	FeatureFlags                     FeatureFlags   `json:"feature_flags"`
 }
 
+// FeatureFlags contains toggles for certain features on the website
 type FeatureFlags struct {
 	HideCookieBanner       bool   `json:"hide_cookie_banner"`
 	ONSDesignSystemVersion string `json:"ons_design_system_version"`

--- a/model/page.go
+++ b/model/page.go
@@ -25,7 +25,8 @@ type Page struct {
 }
 
 type FeatureFlags struct {
-	HideCookieBanner bool `json:"hide_cookie_banner"`
+	HideCookieBanner       bool   `json:"hide_cookie_banner"`
+	ONSDesignSystemVersion string `json:"ons_design_system_version"`
 }
 
 // NewPage instantiates the base Page type with configurable fields


### PR DESCRIPTION
### What

Added a new feature flag, `ONSDesignSystemVersion`, has been added to the base `Page` model. This value can be set to a specific version of the ONS design system (as a string). If the string is not empty, `dp-renderer` will take the value and load the CSS and JS for the ONS design system in tandem to Sixteens.

This is applied on a per-page basis via the page's mapper function. This allows for new pages that use the design system components to be built accordingly, whilst minimising issues across the ONS website that arise due to style conflicts between Sixteens and the design system.

### How to review

- Sense check template and page model changes

#### To test locally

- Pull this branch down and checkout
- Open `dp-frontend-cookie-controller` or `dp-frontend-dataset-controller` (or any other controller that has since been migrated to use `dp-renderer`)
- Use the `replace` keyword in `go.mod` to use your local version of `dp-renderer` ([guide here if you're unfamiliar with this](https://thewebivore.com/using-replace-in-go-mod-to-point-to-your-local-module/))
- Run the relevant frontend app with `make debug`
- Visit a page and inspect the network. You should see no reference to the ONS design system CSS and JS files being fetched from the CDN.
- Update the mapper function of that page to include the line `p.FeatureFlags.ONSDesignSystemVersion = "37.0.0"`
- Reload the app, refresh the page and inspect the network - you should see the ONS design system CSS and JS files fetched from the CDN

### Who can review

Anyone
