### PR TITLE
add isDevelopment bool to unrolled instantation

### DIFF
--- a/client/unrolled.go
+++ b/client/unrolled.go
@@ -15,14 +15,15 @@ type unrolledAdapter struct {
 }
 
 // NewUnrolledAdapter returns the unrolled render library via an adapter struct that satisfies the Renderer interface
-func NewUnrolledAdapter(assetFn func(name string) ([]byte, error), assetNameFn func() []string) Renderer {
+func NewUnrolledAdapter(assetFn func(name string) ([]byte, error), assetNameFn func() []string, isDevelopment bool) Renderer {
 	helper.InitialiseLocalisationsHelper(assetFn)
 	return &unrolledAdapter{
 		unrolled: unrolled.New(render.Options{
-			Asset:      assetFn,
-			AssetNames: assetNameFn,
-			Layout:     "main",
-			Funcs:      []template.FuncMap{helper.RegisteredFuncs},
+			Asset:         assetFn,
+			AssetNames:    assetNameFn,
+			Layout:        "main",
+			IsDevelopment: isDevelopment,
+			Funcs:         []template.FuncMap{helper.RegisteredFuncs},
 		}),
 	}
 }

--- a/render.go
+++ b/render.go
@@ -3,6 +3,7 @@ package render
 import (
 	"context"
 	"io"
+	"strings"
 	"sync"
 
 	"github.com/ONSdigital/dp-renderer/client"
@@ -29,7 +30,11 @@ func New(client client.Renderer, assetsPath, siteDomain string) *Render {
 }
 
 // NewWithDefaultClient returns a render struct with a default rendering client provided (default: unrolled/render)
-func NewWithDefaultClient(assetFn func(name string) ([]byte, error), assetNameFn func() []string, assetsPath, siteDomain string, isDevelopment bool) *Render {
+func NewWithDefaultClient(assetFn func(name string) ([]byte, error), assetNameFn func() []string, assetsPath, siteDomain string) *Render {
+	isDevelopment := false
+	if strings.Contains(siteDomain, "localhost") {
+		isDevelopment = true
+	}
 	return &Render{
 		client:                   client.NewUnrolledAdapter(assetFn, assetNameFn, isDevelopment),
 		hMutex:                   &sync.Mutex{},

--- a/render.go
+++ b/render.go
@@ -29,9 +29,9 @@ func New(client client.Renderer, assetsPath, siteDomain string) *Render {
 }
 
 // NewWithDefaultClient returns a render struct with a default rendering client provided (default: unrolled/render)
-func NewWithDefaultClient(assetFn func(name string) ([]byte, error), assetNameFn func() []string, assetsPath, siteDomain string) *Render {
+func NewWithDefaultClient(assetFn func(name string) ([]byte, error), assetNameFn func() []string, assetsPath, siteDomain string, isDevelopment bool) *Render {
 	return &Render{
-		client:                   client.NewUnrolledAdapter(assetFn, assetNameFn),
+		client:                   client.NewUnrolledAdapter(assetFn, assetNameFn, isDevelopment),
 		hMutex:                   &sync.Mutex{},
 		jMutex:                   &sync.Mutex{},
 		PatternLibraryAssetsPath: assetsPath,

--- a/render.go
+++ b/render.go
@@ -29,7 +29,11 @@ func New(client client.Renderer, assetsPath, siteDomain string) *Render {
 	}
 }
 
-// NewWithDefaultClient returns a render struct with a default rendering client provided (default: unrolled/render)
+/* NewWithDefaultClient returns a render struct with a default rendering client provided (default: unrolled/render)
+When the siteDomain argument contains "localhost", then the rendering client will be instantiated in "development" mode.
+This means that templates are recompiled on request.
+Any updates made to your templates can then be viewed upon browser refresh, rather than having to restart the app.
+*/
 func NewWithDefaultClient(assetFn func(name string) ([]byte, error), assetNameFn func() []string, assetsPath, siteDomain string) *Render {
 	isDevelopment := false
 	if strings.Contains(siteDomain, "localhost") {


### PR DESCRIPTION
### What

Added `isDevelopment` property to default client instantiation so that when running locally, changes to templates do not require a restart of the service

### How to review

Sense check change

You can test locally by loading up either cookie or dataset controller and viewing one of the pages it serves (e.g. `/cookies` for the cookie controller). Make a change to the corresponding template in `assets/templates` and refresh the page. You should see that change reflected in your browser

### Who can review

Anyone
