### PR TITLE
design system beta banner implemented with conditional check

### DIFF
--- a/assets/locales/core.cy.toml
+++ b/assets/locales/core.cy.toml
@@ -229,7 +229,11 @@ one = "Chwilio am allweddair neu ID cyfres amser"
 description = "Beta"
 one = "Beta"
 
-[BetaFeedback]
+[BetaGeneralFeedback]
+description = "General beta banner feedback"
+one = "This is a new service – your <a href=\"/feedback\" class=\"underline-link\">feedback</a> will help us improve it."
+
+[BetaCMDFeedback]
 description = "This is a new way of getting data - your <a href=\"/feedback?service=cmd\">feedback</a> will help us to improve it."
 one = "This is a new way of getting data - your <a href=\"/feedback?service=cmd\">feedback</a> will help us to improve it."
 

--- a/assets/locales/core.en.toml
+++ b/assets/locales/core.en.toml
@@ -225,7 +225,11 @@ one = "Search for a keyword(s) or time series ID"
 description = "Beta"
 one = "Beta"
 
-[BetaFeedback]
+[BetaGeneralFeedback]
+description = "General beta banner feedback"
+one = "This is a new service – your <a href=\"/feedback\" class=\"underline-link\">feedback</a> will help us improve it."
+
+[BetaCMDFeedback]
 description = "This is a new way of getting data - your <a href=\"/feedback?service=cmd\">feedback</a> will help us to improve it."
 one = "This is a new way of getting data - your <a href=\"/feedback?service=cmd\">feedback</a> will help us to improve it."
 

--- a/assets/templates/partials/banners/beta.tmpl
+++ b/assets/templates/partials/banners/beta.tmpl
@@ -1,0 +1,12 @@
+<div class="phase-banner">
+  <div class="container">
+    <div class="grid grid--flex grid--gutterless grid--vertical-center grid--no-wrap u-ml-m u-mr-m">
+      <div class="grid__col col-auto u-flex-no-grow u-flex-no-shrink">
+        <h3 class="phase-banner__badge u-fw-b">{{ localise "Beta" .Language 1}}</h3>
+      </div>
+      <div class="grid__col col-auto u-flex-shrink">
+        <p class="phase-banner__desc u-fs-s u-mb-no">{{ localise "BetaGeneralFeedback" .Language 1 | safeHTML }}</p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/assets/templates/partials/banners/cmd-beta.tmpl
+++ b/assets/templates/partials/banners/cmd-beta.tmpl
@@ -1,0 +1,10 @@
+<div class="banner">
+    <div class="wrapper banner--bottom-border">
+        <div class="col col--md-40 col--lg-44">
+            <span class="banner__text-icon">{{ localise "Beta" .Language 1 }}</span>
+            <div class="banner__body">
+                <p>{{ localise "BetaCMDFeedback" .Language 1 | safeHTML }}</p>
+            </div>
+        </div>
+    </div>
+</div>

--- a/assets/templates/partials/header.tmpl
+++ b/assets/templates/partials/header.tmpl
@@ -237,15 +237,10 @@
 		</div>
     {{end}}
     {{if .BetaBannerEnabled}}
-        <div class="banner">
-            <div class="wrapper banner--bottom-border">
-                <div class="col col--md-40 col--lg-44">
-                    <span class="banner__text-icon">{{ localise "Beta" .Language 1 }}</span>
-                    <div class="banner__body">
-                        <p>{{ localise "BetaFeedback" .Language 1 | safeHTML }}</p>
-                    </div>
-                </div>
-            </div>
-        </div>
+        {{ if .FeatureFlags.ONSDesignSystemVersion }}
+            {{ template "partials/banners/beta" . }}
+        {{ else }}
+            {{ template "partials/banners/cmd-beta" . }}
+        {{ end }}
     {{end}}
 </header>


### PR DESCRIPTION
### What

Added the ONS design system beta banner, for use on pages where `BetaBannerEnabled` is true and `ONSDesignSystemVersion` is also set 

![image](https://user-images.githubusercontent.com/23668262/133251786-7d5b5e22-68b2-4177-aeaa-bb47999b3d0b.png)

![image](https://user-images.githubusercontent.com/23668262/133251868-924f152b-c894-4f6a-bf01-7d6f2f81935b.png)

### How to review

- Check beta banner loads as it ought to, i.e., new banner on census dataset landing page and old one on e.g. CPIH dataset landing page

### Who can review

Anyone
