### PR TITLE
Feature/updating css classes to use namespace

### DIFF
--- a/assets/templates/partials/banners/beta.tmpl
+++ b/assets/templates/partials/banners/beta.tmpl
@@ -1,11 +1,11 @@
-<div class="phase-banner">
-  <div class="container">
-    <div class="grid grid--flex grid--gutterless grid--vertical-center grid--no-wrap u-ml-m u-mr-m">
-      <div class="grid__col col-auto u-flex-no-grow u-flex-no-shrink">
-        <h3 class="phase-banner__badge u-fw-b">{{ localise "Beta" .Language 1}}</h3>
+<div class="ons-phase-banner">
+  <div class="ons-container">
+    <div class="ons-grid ons-grid--flex ons-grid--gutterless ons-grid--vertical-center ons-grid--no-wrap ons-u-ml-m ons-u-mr-m">
+      <div class="ons-grid__col ons-col-auto ons-u-flex-no-grow ons-u-flex-no-shrink">
+        <h3 class="ons-phase-banner__badge ons-u-fw-b">{{ localise "Beta" .Language 1}}</h3>
       </div>
-      <div class="grid__col col-auto u-flex-shrink">
-        <p class="phase-banner__desc u-fs-s u-mb-no">{{ localise "BetaGeneralFeedback" .Language 1 | safeHTML }}</p>
+      <div class="ons-grid__col ons-col-auto ons-u-flex-shrink">
+        <p class="ons-phase-banner__desc ons-u-fs-s ons-u-mb-no">{{ localise "BetaGeneralFeedback" .Language 1 | safeHTML }}</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
### What

- Prefixed `design-system` css classes with 'ons'

### How to review

- Sanity check
- Beta banner should still appear as image ⬇️ 

![image](https://user-images.githubusercontent.com/23668262/133251786-7d5b5e22-68b2-4177-aeaa-bb47999b3d0b.png)

**Note** the css class `underline-link` is required as a `Sixteens` override, when Sixteens is deprecated this class will no longer be required and will fail safe as the design system underlines links as standard. 

### Who can review

Frontend dev
