### PR TITLE
fix utility margin classes for ONS Design System beta banner

### DIFF
--- a/assets/templates/main.tmpl
+++ b/assets/templates/main.tmpl
@@ -65,8 +65,8 @@
     </noscript>
     <!-- End Google Tag Manager (noscript) -->
     {{ if .FeatureFlags.ONSDesignSystemVersion }}
-      <div class="page">
-        <div class="page__content">
+      <div class="ons-page">
+        <div class="ons-page__content">
     {{end}}
         {{ if (ne .FeatureFlags.HideCookieBanner true)}}
           {{ template "partials/banners/cookies" . }}

--- a/assets/templates/partials/banners/beta.tmpl
+++ b/assets/templates/partials/banners/beta.tmpl
@@ -1,6 +1,6 @@
 <div class="ons-phase-banner">
   <div class="ons-container">
-    <div class="ons-grid ons-grid--flex ons-grid--gutterless ons-grid--vertical-center ons-grid--no-wrap ons-u-ml-m ons-u-mr-m">
+    <div class="ons-grid ons-grid--flex ons-grid--gutterless ons-grid--vertical-center ons-grid--no-wrap ons-u-ml-m@m ons-u-mr-m@m ons-u-ml-no">
       <div class="ons-grid__col ons-col-auto ons-u-flex-no-grow ons-u-flex-no-shrink">
         <h3 class="ons-phase-banner__badge ons-u-fw-b">{{ localise "Beta" .Language 1}}</h3>
       </div>


### PR DESCRIPTION
### What

A small fix to the ONS design system-styled beta banner. Updating its utility classes so that the margin is correct when on mobile viewports

Also updated ONS design system specific CSS classes used in `main.tmpl` with the new namespace - `ons-`

![image](https://user-images.githubusercontent.com/23668262/136912993-1ec9229b-efdd-4c2a-bf62-74485651c714.png)

### How to review

- Sense check changes

### Who can review

Anyone
