### PR TITLE
Feature/ui tweaks to census dataset landing page

### DIFF
--- a/assets/templates/icons/download.tmpl
+++ b/assets/templates/icons/download.tmpl
@@ -1,11 +1,12 @@
 <svg
     class="ons-svg-icon"
-    width="14"
-    height="17"
-    viewBox="0 0 14 17"
-    fill="none"
+    viewBox="0 0 12 12"
+    fill="currentColor"
     xmlns="http://www.w3.org/2000/svg"
     focusable="false"
     aria-hidden="true">
-    <path d="M0 17H14V15H0V17ZM14 6H10V0H4V6H0L7 13L14 6Z" fill="#222222"/>
+    <path d="M5.6 9a.48.48 0 0 0 .7 0l3-3.2a.48.48 0 0 0 0-.7C9.3 5 9.2 5 9 5H7.5V.5A.47.47 0 0 0 7 0H5a.47.47 0 0
+        0-.5.5V5H3a.47.47 0 0 0-.5.5.37.37 0 0 0 .1.3Z"/>
+    <path d="M11.5 9H11a.47.47 0 0 0-.5.5v1h-9v-1A.47.47 0 0 0 1 9H.5a.47.47 0 0 0-.5.5v2a.47.47 0 0 0 .5.5h11a.47.47 0 0 0
+    .5-.5v-2a.47.47 0 0 0-.5-.5Z"/>
 </svg>

--- a/assets/templates/main.tmpl
+++ b/assets/templates/main.tmpl
@@ -65,7 +65,7 @@
     </noscript>
     <!-- End Google Tag Manager (noscript) -->
     {{ if .FeatureFlags.ONSDesignSystemVersion }}
-      <div class="ons-page">
+      <div class="page">
         <div class="ons-page__content">
     {{end}}
         {{ if (ne .FeatureFlags.HideCookieBanner true)}}


### PR DESCRIPTION
### What

- Updated download icon to latest from [design-system](https://ons-design-system.netlify.app/foundations/icons/)
- Removed namespaced css class from page div

### How to review

- Pull local branch and check page design is as expected
- Check download icon is latest
- Check page contents component is 'sticky' again
  - The design-system's `ons-page` css class sets the `overflow-x` property to hidden which means the `sticky` setting no longer works. Removing the design-system's class removes this setting.

![image](https://user-images.githubusercontent.com/19624419/137945238-670c7b18-2804-435d-886e-fc6984b51282.png)


### Who can review

Frontend dev
