### PR TITLE
update 'locales' directory name in example structure

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -20,7 +20,7 @@ You should also store all assets and models within the service itself with the f
 .
 ├── assets                   # relevant templates & localisations from dp-frontend-renderer
 │   ├── templates          
-│   ├── localisations  
+│   ├── locales  
 |   |   ├──  service.en.toml
 |   └── └──  service.cy.toml
 └── model                    # relevant models from dp-frontend-models


### PR DESCRIPTION
### What

Updated directory name from 'localisations' to 'locales' in the example assets directory structure.
This is to match the directory names used in the generate-debug and generate-build commands.

### How to review

Ensure only the single word change describe above is included

### Who can review

Anyone but me
