### PR TITLE
Feature/move beta banner

### DIFF
--- a/assets/templates/main.tmpl
+++ b/assets/templates/main.tmpl
@@ -72,6 +72,9 @@
         {{ if (ne .FeatureFlags.HideCookieBanner true)}}
           {{ template "partials/banners/cookies" . }}
         {{ end }}
+        {{ if and ( .BetaBannerEnabled ) ( not .FeatureFlags.SixteensVersion ) }}
+          {{ template "partials/banners/beta" . }}
+        {{ end }}
         {{ template "partials/header" . }}
         <main id="main" role="main" tabindex="-1">
           {{yield}}

--- a/assets/templates/partials/header.tmpl
+++ b/assets/templates/partials/header.tmpl
@@ -269,11 +269,7 @@
             </div>
         </div>
     {{end}}
-    {{if .BetaBannerEnabled}}
-        {{ if .FeatureFlags.SixteensVersion }}
-            {{ template "partials/banners/cmd-beta" . }}
-        {{ else }}
-            {{ template "partials/banners/beta" . }}
-        {{ end }}
-    {{end}}
+    {{ if and .BetaBannerEnabled .FeatureFlags.SixteensVersion }}
+        {{ template "partials/banners/cmd-beta" . }}
+    {{ end }}
 </header>


### PR DESCRIPTION
### What

Moved `beta phase banner` to above the `header` as per the [design system](https://ons-design-system.netlify.app/components/phase-banner/) requirements

### How to review

Sense check
Check images

**Note** you can view these pages if you follow the [guidance](https://github.com/ONSdigital/dp-compose/tree/main/cantabular-import#readme) to setup your local services to perform a cantabular and CMD dataset import (helpers/init-db.sh). Then you should be able to see both instances of the phase banner OR call me and I can show you locally 😄 

#### Phase banner on census pages
![image](https://user-images.githubusercontent.com/19624419/145397538-5d0b415c-2920-461d-be88-b4eb2d2b7e65.png)

#### Phase banner on CMD pages is unchanged
![image](https://user-images.githubusercontent.com/19624419/145398113-4e54651b-1569-4c8c-8a34-4960f524807e.png)

### Who can review

Frontend dev
