### PR TITLE
Fix/removing evaluation against unknown fields

### DIFF
--- a/assets/templates/partials/gtm-data-layer.tmpl
+++ b/assets/templates/partials/gtm-data-layer.tmpl
@@ -30,9 +30,6 @@ dataLayer = [{
     {{if .ReleaseDate }}
         "releaseDate": {{dateFormatYYYYMMDD .ReleaseDate}},
     {{end}}
-    {{if .Data.Response.Count}}
-        "numberOfResults": {{.Data.Response.Count}},
-    {{end}}
     {{ if eq .Type "search" }}
             "newSearch": true,
     {{ end }}


### PR DESCRIPTION
### What

Removed unknown fields that are causing all pages that use the renderer to break
Snippet from stack trace :=
```
"errors": [
    {
      "message": "template: partials/gtm-data-layer:33:14: executing \"partials/gtm-data-layer\" at <.Data.Response.Count>: can't evaluate field Data in type datasetLandingPageFilterable.Page",
```

### How to review

Sense check

### Who can review

Anyone but me
