### PR TITLE
Fix/adding missing logic to hide beta banner

### DIFF
--- a/assets/templates/partials/header.tmpl
+++ b/assets/templates/partials/header.tmpl
@@ -8,7 +8,7 @@
     {{ end }}
     {{ if and ( .BetaBannerEnabled ) ( not .FeatureFlags.SixteensVersion ) }}
         {{ template "partials/banners/beta" . }}
-    {{ else }}
+    {{ else if .BetaBannerEnabled }}
         {{ template "partials/banners/cmd-beta" . }}
     {{ end }}
     


### PR DESCRIPTION
### What

Added missing logic to display beta banner
Previously, banner would display if `BetaBannerEnabled = false` and no `FeatureFlags.SixteensVersion`. This logic fixes this problem

### How to review

Sense check

### Who can review

Anyone but me
