### PR TITLE
Feature/adding collapsible ui component

### DIFF
--- a/PATTERNS.md
+++ b/PATTERNS.md
@@ -1,0 +1,35 @@
+# Using patterns or components in your service
+
+## Collapsible
+
+To instatiate the [collapsible](https://ons-design-system.netlify.app/components/collapsible/) UI component in your service:
+
+- In the `mapper.go` file in your service, populate the relevant fields
+e.g.
+
+```go
+p.Collapsible = coreModel.Collapsible{
+  // You can either use a localisation key or populate the `Title` string
+  LocaliseKey:       "VariablesExplanation",
+  LocalisePluralInt: 4,
+  CollapsibleItems: []coreModel.CollapsibleItem{
+   {
+    Subheading: "This is a subheading",
+    Content:    []string{"a string"},
+   },
+   {
+    Subheading: "This is another subheading",
+    Content:    []string{"another string", "and another"},
+   },
+  },
+ }
+```
+
+- In the template file within your service, reference the `collapsible.tmpl` file
+e.g.
+
+```tmpl
+<div>Some html...</div>
+{{ template "partials/collapsible" . }}
+<div>Some more html</div>
+```

--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ rend.BuildPage(w, mappedPageData, "name-of-template-file-without-extension")
 
 If an error occurs during page build, either because of an incorrect template name or incorrect data mapping, `dp-renderer` will write an error via an `errorResponse` struct.
 
+### Using design patterns or components in your service
+
+See [PATTERNS](PATTERNS.md) for details.
+
 ### Using Sixteens for older pages
 
 As Sixteens is in the process of being deprecated, dp-renderer is designed to use [`dp-design-system`](https://github.com/ONSdigital/dp-design-system) by default.

--- a/assets/locales/core.cy.toml
+++ b/assets/locales/core.cy.toml
@@ -373,3 +373,8 @@ one = "You’ve accepted all cookies. You can <a href=\"/cookies\">change your c
 [CookiesBannerHide]
 description = "Hide"
 one = "Hide"
+
+# Collapsible
+[HideThis]
+description = "Hide this"
+one = "Hide this"

--- a/assets/locales/core.en.toml
+++ b/assets/locales/core.en.toml
@@ -367,3 +367,8 @@ one = "You’ve accepted all cookies. You can <a href=\"/cookies\">change your c
 [CookiesBannerHide]
 description = "Hide"
 one = "Hide"
+
+# Collapsible
+[HideThis]
+description = "Hide this"
+one = "Hide this"

--- a/assets/templates/icons/chevron-left.tmpl
+++ b/assets/templates/icons/chevron-left.tmpl
@@ -1,0 +1,5 @@
+<svg class="ons-svg-icon" viewBox="0 0 8 13" xmlns="http://www.w3.org/2000/svg" focusable="false" fill="currentColor">
+    <path
+        d="M5.74,14.28l-.57-.56a.5.5,0,0,1,0-.71h0l5-5-5-5a.5.5,0,0,1,0-.71h0l.57-.56a.5.5,0,0,1,.71,0h0l5.93,5.93a.5.5,0,0,1,0,.7L6.45,14.28a.5.5,0,0,1-.71,0Z"
+        transform="translate(-5.02 -1.59)"/>
+</svg>

--- a/assets/templates/icons/collapsible.tmpl
+++ b/assets/templates/icons/collapsible.tmpl
@@ -1,0 +1,7 @@
+<span class="ons-collapsible__icon">
+    <svg class="ons-svg-icon" viewBox="0 0 8 13" xmlns="http://www.w3.org/2000/svg" focusable="false">
+        <path
+            d="M5.74,14.28l-.57-.56a.5.5,0,0,1,0-.71h0l5-5-5-5a.5.5,0,0,1,0-.71h0l.57-.56a.5.5,0,0,1,.71,0h0l5.93,5.93a.5.5,0,0,1,0,.7L6.45,14.28a.5.5,0,0,1-.71,0Z"
+            transform="translate(-5.02 -1.59)"></path>
+    </svg>
+</span>

--- a/assets/templates/partials/breadcrumb.tmpl
+++ b/assets/templates/partials/breadcrumb.tmpl
@@ -13,6 +13,8 @@
                         {{ end }}
                         {{ if notLastItem $length $i }}
                             {{ template "icons/chevron-right" }}
+                        {{ else if eq $length 1 }}
+                            {{ template "icons/chevron-left" }}
                         {{ end }}
                     </li>
                 {{ end }}

--- a/assets/templates/partials/collapsible.tmpl
+++ b/assets/templates/partials/collapsible.tmpl
@@ -1,0 +1,29 @@
+<div id="collapsible" class="ons-collapsible ons-js-collapsible" data-btn-close="{{ localise "HideThis" .Language 1 }}">
+    <div class="ons-collapsible__heading ons-js-collapsible-heading">
+        <div class="ons-collapsible__controls">
+            <h3 class="ons-collapsible__title">{{ if .Collapsible.LocaliseKey }}{{ localise .Collapsible.LocaliseKey .Language .Collapsible.LocalisePluralInt }}{{ else }}{{ .Collapsible.Title }}{{ end }}&#63;</h3>
+            {{ template "icons/collapsible" . }}
+        </div>
+    </div>
+    <div id="collapsible-content" class="ons-collapsible__content ons-js-collapsible-content">
+        {{ $length := len .Collapsible.CollapsibleItems }}
+        {{ range .Collapsible.CollapsibleItems }}
+            {{ if .Subheading }}
+                <h4>{{ .Subheading }}</h4>
+            {{ end }}
+            {{ range .Content }}
+                <p class="ons-u-fs-r ons-u-mb-s ons-u-p-no">{{ . }}</p>
+            {{ end }}
+            {{ if ne $length 1 }}
+            <br>
+            {{ end }}
+        {{ end }}
+        <button
+            type="button"
+            class="ons-btn ons-js-collapsible-button ons-u-d-no ons-btn--secondary ons-btn--small"
+            aria-controls="collapsible">
+            <span class="ons-btn__inner ons-js-collapsible-button-inner">{{ localise "HideThis" .Language 1 }}</span>
+            <span class="ons-btn__context ons-u-vh">{{ .Collapsible.Title }} content</span>
+        </button>
+    </div>
+</div>

--- a/assets/templates/partials/footer.tmpl
+++ b/assets/templates/partials/footer.tmpl
@@ -83,7 +83,7 @@
                   {{ if .FeatureFlags.SixteensVersion }}
                      {{ localise "OGLFull" .Language 1 | safeHTML }}
                   {{ else }}
-                     {{ localise "OGLFull" .Language 2 | safeHTML }}
+                     {{ localise "OGLFull" .Language 4 | safeHTML }}
                   {{ end }}
                </p>
             </div>

--- a/model/collapsible.go
+++ b/model/collapsible.go
@@ -1,0 +1,19 @@
+package model
+
+/* Collapsible maps the collapsible UI component.
+The title text can be either a 'Title' or a 'LocaliseKey', the question mark will always render at the end.
+The 'LocaliseKey' has to correspond to the localisation key found in the toml files within assets/locales, otherwise the page will error.
+LocalisePluralInt refers to the plural int used in the toml file.
+*/
+type Collapsible struct {
+	Title             string            `json:"title"`
+	LocaliseKey       string            `json:"localise_key"`
+	LocalisePluralInt int               `json:"localise_plural_int"`
+	CollapsibleItems  []CollapsibleItem `json:"collapsible_item"`
+}
+
+// CollapsibleItem is an individual representation of the data required in a collapsible item
+type CollapsibleItem struct {
+	Subheading string   `json:"subheading"`
+	Content    []string `json:"content"`
+}

--- a/model/page.go
+++ b/model/page.go
@@ -25,6 +25,7 @@ type Page struct {
 	FeatureFlags                     FeatureFlags    `json:"feature_flags"`
 	Error                            Error           `json:"error"`
 	EmergencyBanner                  EmergencyBanner `json:"emergency_banner"`
+	Collapsible                      Collapsible     `json:"collapsible"`
 }
 
 // FeatureFlags contains toggles for certain features on the website


### PR DESCRIPTION
### What

- Added [collapsible component](https://ons-design-system.netlify.app/components/collapsible/); to enable removal from f/end dataset controller
- Altered appearance of single breadcrumb as per [design system](https://ons-design-system.netlify.app/components/breadcrumbs/)
- Fixed bug on pluralisation int

### How to review

- Sense check
  - Template has been lifted from the [dp-frontend-dataset-controller](https://github.com/ONSdigital/dp-frontend-dataset-controller/blob/develop/assets/templates/partials/census/collapsible.tmpl)
- Look at image ⬇️ 
![image](https://user-images.githubusercontent.com/19624419/149305112-20367f6b-47fd-4ccd-9816-29b91f5e8476.png)

### Who can review

Frontend dev
