### PR TITLE
Feature/add new wording beta search banner

### DIFF
--- a/assets/templates/partials/banners/beta.tmpl
+++ b/assets/templates/partials/banners/beta.tmpl
@@ -1,17 +1,19 @@
 <div class="ons-phase-banner">
   <div class="ons-container">
-    <div class="ons-grid ons-grid--flex ons-grid--gutterless ons-grid--vertical-center ons-grid--no-wrap">
+    <div class="ons-grid--flex ons-grid--gutterless ons-grid--no-wrap">
       <div class="ons-grid__col ons-col-auto ons-u-flex-no-grow ons-u-flex-no-shrink">
         <strong class="ons-phase-banner__badge">{{ localise "Beta" .Language 1 }}</strong>
       </div>
       {{ if eq .Type "search" }}
+      <div class="ons-col-auto ons-grid--flex ons-grid--no-wrap@l ons-grid__col">
         <span class="ons-u-fs-s ons-u-m-no">{{ localise "BetaSearchFeedback" .Language 1 | safeHTML }}</span>
-            <form action="/search" method="get">
+            <form class="ons-grid__col" action="/search" method="get">
                 <input type="hidden" id="q" name="q" value="{{ .Data.Query }}">
                 <input type="hidden" id="exit-new-search" name="exit-new-search" value="true">
-                <button type="submit" role="link" class="ons-btn ons-btn__btn--link ons-btn__btn--search default-line-height" name="previous-version" data-gtm-search-exit="true">{{ localise "BetaPreviousVersion" .Language 1 }}</button>
+                <button type="submit" role="link" class="ons-btn ons-btn__btn--link ons-btn__btn--search default-line-height flush--sm" name="previous-version" data-gtm-search-exit="true">{{ localise "BetaPreviousVersion" .Language 1 }}</button>
             </form>
-        <span class="ons-u-fs-s ons-u-m-no">.</span>
+            <span class="ons-u-fs-s ons-u-m-no">.</span>
+      </div>
         {{ else }}
         <span class="ons-grid__col ons-col-auto ons-u-flex-shrink">
             <p class="ons-phase-banner__desc ons-u-fs-s ons-u-m-no">{{ localise "BetaGeneralFeedback" .Language 1 | safeHTML }}</p>

--- a/assets/templates/partials/banners/beta.tmpl
+++ b/assets/templates/partials/banners/beta.tmpl
@@ -2,7 +2,7 @@
   <div class="ons-container">
     <div class="ons-grid ons-grid--flex ons-grid--gutterless ons-grid--vertical-center ons-grid--no-wrap">
       <div class="ons-grid__col ons-col-auto ons-u-flex-no-grow ons-u-flex-no-shrink">
-        <h3 class="ons-phase-banner__badge">{{ localise "Beta" .Language 1 }}</h3>
+        <strong class="ons-phase-banner__badge">{{ localise "Beta" .Language 1 }}</strong>
       </div>
       {{ if eq .Type "search" }}
         <span class="ons-u-fs-s ons-u-m-no">{{ localise "BetaSearchFeedback" .Language 1 | safeHTML }}</span>

--- a/assets/templates/partials/banners/beta.tmpl
+++ b/assets/templates/partials/banners/beta.tmpl
@@ -1,18 +1,18 @@
 <div class="ons-phase-banner">
   <div class="ons-container">
-    <div class="ons-grid--flex ons-grid--gutterless ons-grid--no-wrap">
+    <div class="ons-grid ons-grid--flex ons-grid--gutterless ons-grid--no-wrap">
       <div class="ons-grid__col ons-col-auto ons-u-flex-no-grow ons-u-flex-no-shrink">
         <strong class="ons-phase-banner__badge">{{ localise "Beta" .Language 1 }}</strong>
       </div>
       {{ if eq .Type "search" }}
-      <div class="ons-col-auto ons-grid--flex ons-grid--no-wrap@l ons-grid__col">
-        <span class="ons-u-fs-s ons-u-m-no">{{ localise "BetaSearchFeedback" .Language 1 | safeHTML }}</span>
-            <form class="ons-grid__col" action="/search" method="get">
+      <div class="ons-col-auto ons-grid--flex ons-grid--no-wrap@l ons-grid--vertical-center">
+        <span class="default-line-height ons-u-fs-s ons-u-m-no">{{ localise "BetaSearchFeedback" .Language 1 | safeHTML }}</span>
+            <form action="/search" method="get">
                 <input type="hidden" id="q" name="q" value="{{ .Data.Query }}">
                 <input type="hidden" id="exit-new-search" name="exit-new-search" value="true">
-                <button type="submit" role="link" class="ons-btn ons-btn__btn--link ons-btn__btn--search default-line-height flush--sm" name="previous-version" data-gtm-search-exit="true">{{ localise "BetaPreviousVersion" .Language 1 }}</button>
+                <button type="submit" role="link" class="default-line-height ons-btn ons-btn__btn--link ons-btn__btn--search flush--sm" name="previous-version" data-gtm-search-exit="true">{{ localise "BetaPreviousVersion" .Language 1 }}</button>
             </form>
-            <span class="ons-u-fs-s ons-u-m-no">.</span>
+            <span class="default-line-height ons-u-fs-s ons-u-m-no">.</span>
       </div>
         {{ else }}
         <span class="ons-grid__col ons-col-auto ons-u-flex-shrink">


### PR DESCRIPTION
### What

Make banner responsive across Chrome, Firefox, and IE on Mac and Windows and appears on one line when using a text spacing tool on desktop. 

### How to review

See that beta banner is one line across large/medium viewports; on small viewports first two sentences wrap, last sentence is stacked beneath.

### Who can review

Frontend dev
