### PR TITLE
try to load the local time once, limit error/stacktrace logging

### DIFF
--- a/helper/date_format.go
+++ b/helper/date_format.go
@@ -8,6 +8,8 @@ import (
 	"github.com/ONSdigital/log.go/v2/log"
 )
 
+var tz *time.Location
+
 func DateFormat(s string) string {
 	t, err := time.Parse(time.RFC3339, s)
 	if err != nil {
@@ -48,10 +50,16 @@ func DateFormatYYYYMMDDNoSlash(s string) string {
 	return template.HTMLEscapeString(t.Format("20060102"))
 }
 
-func localiseTime(t *time.Time) time.Time {
-	tz, err := time.LoadLocation("Europe/London")
-	if err != nil {
+func init() {
+	var err error
+	if tz, err = time.LoadLocation("Europe/London"); err != nil {
 		log.Error(context.Background(), "failed to load timezone", err)
+		tz = nil
+	}
+}
+
+func localiseTime(t *time.Time) time.Time {
+	if tz == nil {
 		return *t
 	}
 	return t.In(tz)


### PR DESCRIPTION
### What

seeing lots (I mean _lots_, like hundreds of thousands!) of logs complaining `failed to load timezone`
every log has a stacktrace with it - filling up discs 😱 

the load isn't going to suddenly work, so why try it so often? more importantly, why log it so often?

this PR makes the load of the location (which will fail, see below) to be called once only, and hence log only once - at app start

### How to review

run in a docker container that doesn't have the timezone files 😢 

### Who can review

you
