### PR TITLE
Further processing for certain strings

### DIFF
--- a/helper/date_period_format.go
+++ b/helper/date_period_format.go
@@ -3,6 +3,7 @@ package helper
 import (
 	"strconv"
 	"strings"
+	"time"
 )
 
 // DatePeriodFormat will format a time-series date period string to a human accessible format e.g.
@@ -39,16 +40,33 @@ func DatePeriodFormat(s string) string {
 		s = s[:Q4] + "Oct - Dec" + s[Q4EndIndex:]
 
 	}
+
 	// 3. Move year to end of string if present and insert a space
-	if _, err := strconv.Atoi(s[:4]); err == nil {
+	year, err := strconv.Atoi(s[:4])
+	if err == nil {
 		// Not just displaying year but month as well
-		if len(s) > 5 {
+		// YYYY[space]DEC[space]-[space]JAN = 14 characters
+		if len(s) == 14 {
+			monthStart, _ := time.Parse("Jan", s[5:8])
+			monthEnd, _ := time.Parse("Jan", s[11:])
+
+			dateStart := monthStart.AddDate(year, 0, 0)
+			dateEnd := monthEnd.AddDate(year, 0, 0)
+
+			if dateStart.After(dateEnd) {
+				dateEnd = dateEnd.AddDate(1, 0, 0)
+				s = dateStart.Format("Jan 2006")
+			} else {
+				s = dateStart.Format("Jan")
+			}
+			s = s + " - " + dateEnd.Format("Jan 2006")
+		} else if len(s) > 5 {
 			// YYYY[space] = 5 characters
 			postYearIndex := 5
 			s = s[postYearIndex:] + " " + s[:4]
-
 		}
 	}
+
 	// 4. Convert BLOCK CAPS to Title Caps
 	timePeriodFormatted := strings.Title(strings.ToLower(s))
 	return timePeriodFormatted

--- a/helper/date_period_format_test.go
+++ b/helper/date_period_format_test.go
@@ -14,6 +14,11 @@ func TestDatePeriodFormat(t *testing.T) {
 		got := helper.DatePeriodFormat("2010 JUN-SEP")
 		So(got, ShouldEqual, want)
 	})
+	Convey("Given a time-series monthly string spanning two different years", t, func() {
+		want := "Dec 2010 - Jan 2011"
+		got := helper.DatePeriodFormat("2010 DEC-JAN")
+		So(got, ShouldEqual, want)
+	})
 	Convey("Given a time-series yearly string", t, func() {
 		want := "2019"
 		got := helper.DatePeriodFormat("2019")


### PR DESCRIPTION
What
Added further processing of string if over a certain length i.e. if the string containing the date range holds two months and a year.

Fix needed because original code would move year provided by the start month and put it after the end month resulting in 2020 DEC - FEB becoming DEC - FEB 2020 when it should be DEC - FEB 2021.

Further discussions has resulted in the desired output being DEC 2020 - FEB 2021 and the code added reflects that desire.

How to review
LGTM / Feel free to pull and check locally.

Who can review
Someone familiar with GO