### PR TITLE
Create compact-search component

### DIFF
--- a/assets/templates/partials/compact-search.tmpl
+++ b/assets/templates/partials/compact-search.tmpl
@@ -1,0 +1,30 @@
+<div class="ons-field">
+  <label
+    class="ons-label ons-u-pb-xs ons-u-fw-n"
+    for="{{ .ElementId }}"
+  >
+    {{ if .LabelLocaliseKey }}
+      {{ localise .LabelLocaliseKey .Language 1 }}:
+    {{ else }}
+      {{ .Label }}:
+    {{ end }}
+  </label>
+  <div class="ons-compact-search">
+    <input
+      type="search"
+      class="ons-compact-search__input"
+      value="{{ .SearchTerm }}"
+      id="{{ .ElementId }}"
+      name="{{ .InputName }}"
+    >
+    <button
+      type="submit"
+      class="ons-btn ons-compact-search__btn"
+    >
+      <span class="visuallyhidden">
+        {{ localise "Search" .Language 1 }}
+      </span>
+      {{ template "icons/search" . }}
+    </button>
+  </div>
+</div>

--- a/model/compact_search.go
+++ b/model/compact_search.go
@@ -1,0 +1,10 @@
+package model
+
+type CompactSearch struct {
+	ElementId        string `json:"element_id"`
+	InputName        string `json:"input_name"`
+	Language         string `json:"language"`
+	LabelLocaliseKey string `json:"label_localise_key"`
+	Label            string `json:"label"`
+	SearchTerm       string `json:"search_term"`
+}


### PR DESCRIPTION
### What

Create a 'compact search' component that looks like this:

<img width="298" alt="Screenshot 2022-03-21 at 16 36 10" src="https://user-images.githubusercontent.com/912770/159310677-4d8496d7-958a-4664-b081-6f48cabb7d90.png">

In comparison to the existing ONS Design System search components that keep their search button (visually) outside the text input like this:

<img width="526" alt="Screenshot 2022-03-21 at 16 38 10" src="https://user-images.githubusercontent.com/912770/159310956-79d7007b-5d30-43d3-8912-f56771fc36f6.png">

#### Usage example

Go mapping

```go
page.KeywordSearch = coreModel.CompactSearch{
    ElementId:  "keyword-search",
    InputName:  "keywords",
    Language:   page.Language,
    Label:      "Search keywords",
    SearchTerm: "zip zap zoo",
}
```

Go template

```html
<form
  role="search"
  aria-label="Keywords"
>
  {{ template "partials/compact-search" .KeywordSearch }}
</form>
```

Rendered Page

<img width="483" alt="Screenshot 2022-03-21 at 16 36 25" src="https://user-images.githubusercontent.com/912770/159311022-5e2d5bde-cf42-409f-ad36-305e8192a0ca.png">

### How to review

Check structure and model.

### Who can review

Frontend / Design System developers.
