### PR TITLE
Localised pagination component

### DIFF
--- a/PATTERNS.md
+++ b/PATTERNS.md
@@ -156,14 +156,15 @@ setting `PagesToDisplay = { 1, 2, 3, 4 }` closes the gap between
 1 2 3 4 ... 10
 ```
 
-Similarly, setting `PagesToDisplay = { 7, 8, 9 10 }` closes the
+Similarly, setting `PagesToDisplay = { 7, 8, 9, 10 }` closes the
 gap between 9 and 10 (a bookend):
 
 1 ... 7 8 9 10
 
 When the window defined by `PagesToDisplay` does not overlap with
 the bookends defined in `FirstAndLastPages`, the page options are
-rendered as:
+rendered with ellipsis between both bookends. For example, setting
+`PagesToDisplay = { 4, 5, 6 }` renders as:
 
 ```
 1 ... 4 5 6 ... 10

--- a/PATTERNS.md
+++ b/PATTERNS.md
@@ -83,3 +83,102 @@ keys to enable localisation:
 
 - `AriaLabel` may be overridden by `AriaLabelLocaliseKey`
 - `Title` may be overridden by `TitleLocaliseKey`
+
+## Pagination
+
+To instatiate the [pagination](https://ons-design-system.netlify.app/components/pagination/) UI component in your service:
+
+- In the `mapper.go` file in your service, populate the relevant fields:
+
+```go
+page.Pagination = Pagination{
+  CurrentPage: 5,
+  TotalPages: 10,
+  Limit: 10,
+  LimitOptions: []int{
+    10,
+    20,
+  },
+  FirstAndLastPages: []PageToDisplay{
+    {
+      PageNumber: 1,
+      URL: "results/1",
+    },
+    {
+      PageNumber: 10,
+      URL: "results/10",
+    },
+  },
+  PagesToDisplay: []PageToDisplay{
+    {
+      PageNumber: 4,
+      URL: "results/4",
+    },
+    {
+      PageNumber: 5,
+      URL: "results/5",
+    },
+    {
+      PageNumber: 6,
+      URL: "results/6",
+    },
+  },
+}
+```
+
+`Limit` represents the number of results shown at once a.k.a.
+results per page.
+
+`LimitOptions` is currently unused, and is therefore optional. It
+represents the available result limits. If used, `Limit` should
+be set to one of the available options in `LimitOptions`.
+
+Offering the user the choice of how many results per page should be
+shown could be done by extending the `Pagination` component or
+creating a new component intended to be used alongside the
+`Pagination` component that consumes this same `Pagination` model.
+
+`FirstAndLastPages` and `PagesToDisplay` interact with each other
+to govern the way available pages are displayed.
+
+`FirstAndLastPages` are used to bookend the row of page numbers.
+They are always visible.
+
+`PagesToDisplay` represents a moving window into all possible
+pages. When this window overlaps a bookend, there will be no
+ellipsis (...) shown between the window and the bookend.
+
+For example, with 1 and 10 as bookends defined in `FirstAndLastPages`,
+setting `PagesToDisplay = { 1, 2, 3, 4 }` closes the gap between
+1 (a bookend) and 2:
+
+```
+1 2 3 4 ... 10
+```
+
+Similarly, setting `PagesToDisplay = { 7, 8, 9 10 }` closes the
+gap between 9 and 10 (a bookend):
+
+1 ... 7 8 9 10
+
+When the window defined by `PagesToDisplay` does not overlap with
+the bookends defined in `FirstAndLastPages`, the page options are
+rendered as:
+
+```
+1 ... 4 5 6 ... 10
+```
+
+- In the template file within your service, reference the
+`pagination.tmpl` file, where `.` is the Page model:
+
+```tmpl
+<div>Some html...</div>
+{{ template "partials/pagination" . }}
+<div>Some more html</div>
+```
+
+### Localisation
+
+All translations live in `assets/locales/core.<language>.toml` and
+are prefixed with `Pagination`.

--- a/PATTERNS.md
+++ b/PATTERNS.md
@@ -148,18 +148,21 @@ They are always visible.
 pages. When this window overlaps a bookend, there will be no
 ellipsis (...) shown between the window and the bookend.
 
+The size of this window is up to you. In the examples that follow
+it is set to three.
+
 For example, with 1 and 10 as bookends defined in `FirstAndLastPages`,
-setting `PagesToDisplay = { 1, 2, 3, 4 }` closes the gap between
+setting `PagesToDisplay = { 1, 2, 3 }` closes the gap between
 1 (a bookend) and 2:
 
 ```
-1 2 3 4 ... 10
+1 2 3 ... 10
 ```
 
-Similarly, setting `PagesToDisplay = { 7, 8, 9, 10 }` closes the
+Similarly, setting `PagesToDisplay = { 8, 9, 10 }` closes the
 gap between 9 and 10 (a bookend):
 
-1 ... 7 8 9 10
+1 ... 8 9 10
 
 When the window defined by `PagesToDisplay` does not overlap with
 the bookends defined in `FirstAndLastPages`, the page options are

--- a/assets/locales/core.en.toml
+++ b/assets/locales/core.en.toml
@@ -460,3 +460,44 @@ other = "Table of contents"
 description = "Contents"
 one = "Contents"
 other = "Contents"
+
+# Pagination
+[Pagination]
+description = "Pagination"
+one = "Pagination"
+
+[PaginationPage]
+description = "Page"
+one = "Page"
+
+[PaginationOf]
+description = "of"
+one = "of"
+
+[PaginationGoPrevious]
+description = "Go to the previous page"
+one = "Go to the previous page"
+
+[PaginationGoFirst]
+description = "Go to the first page"
+one = "Go to the first page"
+
+[PaginationCurrentPage]
+description = "Current page"
+one = "Current page"
+
+[PaginationGoLast]
+description = "Go to the last page"
+one = "Go to the last page"
+
+[PaginationGoNext]
+description = "Go to the next page"
+one = "Go to the next page"
+
+[PaginationPrevious]
+description = "Previous"
+one = "Previous"
+
+[PaginationNext]
+description = "Next"
+one = "Next"

--- a/assets/templates/partials/pagination.tmpl
+++ b/assets/templates/partials/pagination.tmpl
@@ -1,0 +1,91 @@
+{{ $pagination := .Pagination }}
+{{ $language := .Language }}
+{{ $pageCurrentofTotal := $pagination.PhrasePageNOfTotal $pagination.CurrentPage $language }}
+{{ $previousURL := $pagination.PickPreviousURL }}
+{{ $nextURL := $pagination.PickNextURL }}
+
+{{ if ne $pagination.TotalPages 0 }}
+  <nav
+    class="ons-pagination"
+    arial-label="{{ $pagination.PhrasePaginationProgress $pageCurrentofTotal $language }}"
+  >
+    <div class="ons-pagination__position ons-u-mb-xs">{{ $pageCurrentofTotal }}</div>
+
+    <ul class="ons-pagination__items">
+      {{ if gt $pagination.CurrentPage 1 }}
+        <li class="ons-pagination__item ons-pagination__item--previous">
+          <a
+            href="{{ $previousURL }}"
+            class="ons-pagination__link"
+            rel="prev"
+            aria-label="{{ $pagination.PhraseGoToPreviousPage $language }}"
+          >
+            {{- localise "PaginationPrevious" $language 1 -}}
+          </a>
+        </li>
+      {{ end }}
+
+      {{ if $pagination.ShowLinkToFirst }}
+        <li class="ons-pagination__item">
+          <a
+            href="{{(index $pagination.FirstAndLastPages 0).URL}}"
+            class="ons-pagination__link"
+            aria-label="{{ $pagination.PhraseGoToFirstPage $language }}"
+          >1</a>
+        </li>
+        <li class="ons-pagination__item ons-pagination__item--gap">&hellip;</li>
+      {{ end }}
+
+      {{ range $pagination.PagesToDisplay }}
+        {{ if eq .PageNumber $pagination.CurrentPage }}
+          <li class="ons-pagination__item ons-pagination__item--current">
+            <a
+              href="{{ .URL}}"
+              class="ons-pagination__link"
+              aria-current="true"
+              aria-label="{{ $pagination.PhraseCurrentPage $pageCurrentofTotal $language }}"
+            >
+              {{- .PageNumber -}}
+            </a>
+          </li>
+        {{ else }}
+          <li class="ons-pagination__item">
+            <a
+              href="{{ .URL}}"
+              class="ons-pagination__link"
+              aria-label="{{ $pagination.PhrasePageNOfTotal .PageNumber $language }}"
+            >
+              {{-  .PageNumber -}}
+            </a>
+          </li>
+        {{ end }}
+      {{ end }}
+
+      {{ if $pagination.ShowLinkToLast }}
+        <li class="ons-pagination__item ons-pagination__item--gap">&hellip;</li>
+        <li class="ons-pagination__item">
+          <a
+            href="{{(index $pagination.FirstAndLastPages 1).URL}}"
+            class="ons-pagination__link"
+            aria-label="{{ $pagination.PhraseGoToLastPage $language }}"
+          >
+            {{- $pagination.TotalPages -}}
+          </a>
+        </li>
+      {{ end }}
+
+      {{ if lt $pagination.CurrentPage $pagination.TotalPages }}
+        <li class="ons-pagination__item ons-pagination__item--next">
+          <a
+            href="{{ $nextURL }}"
+            class="ons-pagination__link"
+            rel="next"
+            aria-label="{{ $pagination.PhraseGoToNextPage $language }}"
+          >
+            {{- localise "PaginationNext" $language 1 -}}
+          </a>
+        </li>
+      {{ end }}
+    </ul>
+  </nav>
+{{ end }}

--- a/assets/templates/partials/pagination.tmpl
+++ b/assets/templates/partials/pagination.tmpl
@@ -3,14 +3,12 @@
 {{ $pageCurrentofTotal := $pagination.PhrasePageNOfTotal $pagination.CurrentPage $language }}
 {{ $previousURL := $pagination.PickPreviousURL }}
 {{ $nextURL := $pagination.PickNextURL }}
-
 {{ if ne $pagination.TotalPages 0 }}
   <nav
     class="ons-pagination"
     arial-label="{{ $pagination.PhrasePaginationProgress $pageCurrentofTotal $language }}"
   >
     <div class="ons-pagination__position ons-u-mb-xs">{{ $pageCurrentofTotal }}</div>
-
     <ul class="ons-pagination__items">
       {{ if gt $pagination.CurrentPage 1 }}
         <li class="ons-pagination__item ons-pagination__item--previous">
@@ -24,7 +22,6 @@
           </a>
         </li>
       {{ end }}
-
       {{ if $pagination.ShowLinkToFirst }}
         <li class="ons-pagination__item">
           <a
@@ -35,7 +32,6 @@
         </li>
         <li class="ons-pagination__item ons-pagination__item--gap">&hellip;</li>
       {{ end }}
-
       {{ range $pagination.PagesToDisplay }}
         {{ if eq .PageNumber $pagination.CurrentPage }}
           <li class="ons-pagination__item ons-pagination__item--current">
@@ -60,7 +56,6 @@
           </li>
         {{ end }}
       {{ end }}
-
       {{ if $pagination.ShowLinkToLast }}
         <li class="ons-pagination__item ons-pagination__item--gap">&hellip;</li>
         <li class="ons-pagination__item">
@@ -73,7 +68,6 @@
           </a>
         </li>
       {{ end }}
-
       {{ if lt $pagination.CurrentPage $pagination.TotalPages }}
         <li class="ons-pagination__item ons-pagination__item--next">
           <a

--- a/model/pagination.go
+++ b/model/pagination.go
@@ -1,5 +1,11 @@
 package model
 
+import (
+	"fmt"
+
+	"github.com/ONSdigital/dp-renderer/helper"
+)
+
 // Pagination represents all information regarding pagination of search results
 type Pagination struct {
 	CurrentPage       int             `json:"current_page"`
@@ -14,4 +20,82 @@ type Pagination struct {
 type PageToDisplay struct {
 	PageNumber int    `json:"page_number"`
 	URL        string `json:"url"`
+}
+
+// Produces a string of the form "Page 1 of 10"
+func (pagination Pagination) PhrasePageNOfTotal(n int, language string) string {
+	phrasePage := helper.Localise("PaginationPage", language, 1)
+	phraseOf := helper.Localise("PaginationOf", language, 1)
+	return fmt.Sprintf("%s %d %s %d", phrasePage, n, phraseOf, pagination.TotalPages)
+}
+
+// Produces a string of the form "Pagination (Page 1 of 10)"
+func (pagination Pagination) PhrasePaginationProgress(progress, language string) string {
+	phrasePagination := helper.Localise("Pagination", language, 1)
+	return fmt.Sprintf("%s (%s)", phrasePagination, progress)
+}
+
+// Produces a string of the form "Go to the previous page (Page 4)"
+func (pagination Pagination) PhraseGoToPreviousPage(language string) string {
+	phrasePage := helper.Localise("PaginationPage", language, 1)
+	phraseGoPrevious := helper.Localise("PaginationGoPrevious", language, 1)
+	pageNumber := pagination.CurrentPage - 1
+	return fmt.Sprintf("%s (%s %d)", phraseGoPrevious, phrasePage, pageNumber)
+}
+
+// Produces a string of the form "Go to the next page (Page 6)"
+func (pagination Pagination) PhraseGoToNextPage(language string) string {
+	phrasePage := helper.Localise("PaginationPage", language, 1)
+	phraseGoNext := helper.Localise("PaginationGoNext", language, 1)
+	pageNumber := pagination.CurrentPage + 1
+	return fmt.Sprintf("%s (%s %d)", phraseGoNext, phrasePage, pageNumber)
+}
+
+// Produces a string of the form "Go to the first page (Page 1)"
+func (pagination Pagination) PhraseGoToFirstPage(language string) string {
+	phrasePage := helper.Localise("PaginationPage", language, 1)
+	phraseGoFirst := helper.Localise("PaginationGoFirst", language, 1)
+	return fmt.Sprintf("%s (%s 1)", phraseGoFirst, phrasePage)
+}
+
+// Produces a string of the form "Current page (Page 5 of 10)"
+func (pagination Pagination) PhraseCurrentPage(progress, language string) string {
+	phrasePagination := helper.Localise("PaginationCurrentPage", language, 1)
+	return fmt.Sprintf("%s (%s)", phrasePagination, progress)
+}
+
+// Produces a string of the form "Go to the last page (Page 10)"
+func (pagination Pagination) PhraseGoToLastPage(language string) string {
+	phrasePage := helper.Localise("PaginationPage", language, 1)
+	phraseGoLast := helper.Localise("PaginationGoLast", language, 1)
+	return fmt.Sprintf("%s (%s %d)", phraseGoLast, phrasePage, pagination.TotalPages)
+}
+
+func (pagination Pagination) PickPreviousURL() string {
+	for _, pageToDisplay := range pagination.PagesToDisplay {
+		if pageToDisplay.PageNumber == pagination.CurrentPage-1 {
+			return pageToDisplay.URL
+		}
+	}
+
+	return "#"
+}
+
+func (pagination Pagination) PickNextURL() string {
+	for _, pageToDisplay := range pagination.PagesToDisplay {
+		if pageToDisplay.PageNumber == pagination.CurrentPage+1 {
+			return pageToDisplay.URL
+		}
+	}
+
+	return "#"
+}
+
+func (pagination Pagination) ShowLinkToFirst() bool {
+	return pagination.PagesToDisplay[0].PageNumber > 1
+}
+
+func (pagination Pagination) ShowLinkToLast() bool {
+	lastPage := len(pagination.PagesToDisplay) - 1
+	return pagination.PagesToDisplay[lastPage].PageNumber != pagination.TotalPages
 }


### PR DESCRIPTION
### What

Implements the [Pagination](https://ons-design-system.netlify.app/components/pagination/) component from the ONS Design System as a Go template.

<img width="657" alt="Screenshot 2022-03-23 at 18 25 18" src="https://user-images.githubusercontent.com/912770/159769960-4fb910f5-94f3-4385-9426-5c18a70465e0.png">

This version is based on the implementation in [dp-frontend-search-controller](https://github.com/ONSdigital/dp-frontend-search-controller/blob/develop/assets/templates/partials/pagination.tmpl), and keeps the existing Pagination model.

Differences:
- Supports localisation (Welsh translations pending, separate ticket already created to handle this)
- More readable template, with logic extracted into helper functions

### How to review

Check the structure and approach are sound.

### Who can review

Frontend / ONS Design System developers, or anyone who worked on the original found in dp-frontend-search-controller.

