### PR TITLE
Replace text and keys with standardised Localisation model

### DIFF
--- a/LOCALISATION.md
+++ b/LOCALISATION.md
@@ -1,0 +1,63 @@
+# Localisation
+
+Components (template partials) can be localised via
+- dp-renderer's `assets/locales`, or
+- your frontend's `assets/locales`, or
+- string literals passed into the component model
+
+## Localisation model
+
+Wherever a component uses the Localisation model, for example:
+
+```
+package model
+
+type Button struct {
+  Label Localisation
+}
+```
+
+The `Label` can be set in one of two ways. Either the `LocaleKey` and `Plural`
+are set, or its `Text` can be set.
+
+When the `LocaleKey` and `Plural` are provided, these take precedence over
+`Text`.
+
+### LocaleKey and Plural
+
+Providing a `LocaleKey` and `Plural` allows a component template to query the
+locale files for a translation.
+
+In your frontend mapper this would look like:
+
+```
+page.Button = model.Button{
+  Label: model.Localisation{
+    LocaleKey: "ButtonClickMe",
+    Plural: 1,
+  },
+}
+```
+
+The dp-renderer's locales and your frontend's locales are effectively combined,
+sharing a namespace. This makes the components in dp-renderer more easily
+reusable because they can refer to locale keys found in the frontend.
+
+The drawback of locales sharing a namespace is that a frontend must take care
+not to use a key already present in the dp-renderer's locales.
+
+### Text
+
+Setting `Text` to a string is useful when
+- No localisation is needed, or
+- The text is already localised (perhaps retrieved from an external source)
+
+In your frontend mapper this would look like:
+
+```
+page.Button = model.Button{
+  Label: model.Localisation{
+    Text: "Click me"
+  },
+}
+```

--- a/assets/templates/partials/collapsible.tmpl
+++ b/assets/templates/partials/collapsible.tmpl
@@ -1,7 +1,7 @@
 <div id="collapsible" class="ons-collapsible ons-js-collapsible" data-btn-close="{{ localise "HideThis" .Language 1 }}">
     <div class="ons-collapsible__heading ons-js-collapsible-heading">
         <div class="ons-collapsible__controls">
-            <h3 class="ons-collapsible__title">{{ if .Collapsible.LocaliseKey }}{{ localise .Collapsible.LocaliseKey .Language .Collapsible.LocalisePluralInt }}{{ else }}{{ .Collapsible.Title }}{{ end }}</h3>
+            <h3 class="ons-collapsible__title">{{ if .Collapsible.Title.LocaleKey }}{{ localise .Collapsible.Title.LocaleKey .Language .Collapsible.Title.Plural }}{{ else }}{{ .Collapsible.Title.Text }}{{ end }}</h3>
             {{ template "icons/collapsible" . }}
         </div>
     </div>
@@ -23,7 +23,7 @@
             class="ons-btn ons-js-collapsible-button ons-u-d-no ons-btn--secondary ons-btn--small"
             aria-controls="collapsible">
             <span class="ons-btn__inner ons-js-collapsible-button-inner">{{ localise "HideThis" .Language 1 }}</span>
-            <span class="ons-btn__context ons-u-vh">{{ .Collapsible.Title }} content</span>
+            <span class="ons-btn__context ons-u-vh">{{ .Collapsible.Title.Text }} content</span>
         </button>
     </div>
 </div>

--- a/assets/templates/partials/compact-search.tmpl
+++ b/assets/templates/partials/compact-search.tmpl
@@ -3,10 +3,10 @@
     class="ons-label ons-u-pb-xs ons-u-fw-n"
     for="{{ .ElementId }}"
   >
-    {{ if .LabelLocaliseKey }}
-      {{ localise .LabelLocaliseKey .Language 1 }}:
+    {{ if .Label.LocaleKey }}
+      {{ localise .Label.LocaleKey .Language .Label.Plural }}:
     {{ else }}
-      {{ .Label }}:
+      {{ .Label.Text }}:
     {{ end }}
   </label>
   <div class="ons-compact-search">

--- a/assets/templates/partials/input-date.tmpl
+++ b/assets/templates/partials/input-date.tmpl
@@ -1,8 +1,16 @@
 <fieldset id="{{ .Id }}" class="ons-fieldset">
   <legend class="ons-fieldset__legend">
-    {{- .Title -}}
+    {{ if .Title.LocaleKey }}
+      {{- localise .Title.LocaleKey .Language .Title.Plural -}}
+    {{ else }}
+      {{- .Title.Text -}}
+    {{ end }}
     <div class="ons-fieldset__description">
-      {{- .Description -}}
+      {{ if .Description.LocaleKey }}
+        {{- localise .Description.LocaleKey .Language .Description.Plural -}}
+      {{ else }}
+        {{- .Description.Text -}}
+      {{ end }}
     </div>
   </legend>
   <div class="ons-field-group">

--- a/assets/templates/partials/table-of-contents.tmpl
+++ b/assets/templates/partials/table-of-contents.tmpl
@@ -20,14 +20,15 @@
       {{ $sections := .TableOfContents.Sections }}
       {{ range $id := .TableOfContents.DisplayOrder }}
         {{ $section := index $sections $id }}
-        <li
-          class="ons-list__item"
-          {{ if $section.Current }}
-            aria-current="true"
-          {{ end }}
-        >
-          <a href="#{{ $id }}" class="ons-list__link">{{ $section.Title }}</a>
-        </li>
+       <li class="ons-list__item" {{ if $section.Current }} aria-current="true" {{ end }}>
+          <a href="#{{ $id }}" class="ons-list__link">
+            {{ if $section.Title.LocaleKey }}
+              {{ localise $section.Title.LocaleKey $.Language $section.Title.Plural }}
+            {{ else }}
+              {{ $section.Title }}
+            {{ end }}
+          </a>
+        <li>
       {{ end }}
     </ol>
   </nav>

--- a/assets/templates/partials/table-of-contents.tmpl
+++ b/assets/templates/partials/table-of-contents.tmpl
@@ -3,17 +3,17 @@
 <aside class="ons-toc-container" role="complementary">
   <nav
     class="ons-toc"
-    {{ if .TableOfContents.AriaLabelLocaliseKey }}
-      aria-label="{{ localise .TableOfContents.AriaLabelLocaliseKey .Language 1 }}"
+    {{ if .TableOfContents.AriaLabel.LocaleKey }}
+      aria-label="{{ localise .TableOfContents.AriaLabel.LocaleKey .Language .TableOfContents.AriaLabel.Plural }}"
     {{ else }}
-      aria-label="{{ .TableOfContents.AriaLabel }}"
+      aria-label="{{ .TableOfContents.AriaLabel.Text }}"
     {{ end }}
   >
     <h2 class="ons-toc__title ons-u-fs-r--b ons-u-mb-s">
-      {{ if .TableOfContents.TitleLocaliseKey }}
-        {{ localise .TableOfContents.TitleLocaliseKey .Language 1 }}
+      {{ if .TableOfContents.Title.LocaleKey }}
+        {{ localise .TableOfContents.Title.LocaleKey .Language .TableOfContents.Title.Plural }}
       {{ else }}
-        {{ .TableOfContents.Title }}
+        {{ .TableOfContents.Title.Text }}
       {{ end }}
     </h2>
     <ol class="ons-list ons-u-mb-m ons-list--dashed">

--- a/model/collapsible.go
+++ b/model/collapsible.go
@@ -6,10 +6,8 @@ The 'LocaliseKey' has to correspond to the localisation key found in the toml fi
 LocalisePluralInt refers to the plural int used in the toml file.
 */
 type Collapsible struct {
-	Title             string            `json:"title"`
-	LocaliseKey       string            `json:"localise_key"`
-	LocalisePluralInt int               `json:"localise_plural_int"`
-	CollapsibleItems  []CollapsibleItem `json:"collapsible_item"`
+	Title            Localisation      `json:"title"`
+	CollapsibleItems []CollapsibleItem `json:"collapsible_item"`
 }
 
 // CollapsibleItem is an individual representation of the data required in a collapsible item

--- a/model/compact_search.go
+++ b/model/compact_search.go
@@ -1,5 +1,6 @@
 package model
 
+// CompactSearch data
 type CompactSearch struct {
 	ElementId  string       `json:"element_id"`
 	InputName  string       `json:"input_name"`

--- a/model/compact_search.go
+++ b/model/compact_search.go
@@ -1,10 +1,9 @@
 package model
 
 type CompactSearch struct {
-	ElementId        string `json:"element_id"`
-	InputName        string `json:"input_name"`
-	Language         string `json:"language"`
-	LabelLocaliseKey string `json:"label_localise_key"`
-	Label            string `json:"label"`
-	SearchTerm       string `json:"search_term"`
+	ElementId  string       `json:"element_id"`
+	InputName  string       `json:"input_name"`
+	Language   string       `json:"language"`
+	Label      Localisation `json:"label"`
+	SearchTerm string       `json:"search_term"`
 }

--- a/model/input_date.go
+++ b/model/input_date.go
@@ -1,14 +1,14 @@
 package model
 
 type InputDate struct {
-	Language        string `json:"language"`
-	Id              string `json:"id"`
-	InputNameDay    string `json:"input_name_day"`
-	InputNameMonth  string `json:"input_name_month"`
-	InputNameYear   string `json:"input_name_year"`
-	InputValueDay   string `json:"input_value_day"`
-	InputValueMonth string `json:"input_value_month"`
-	InputValueYear  string `json:"input_value_year"`
-	Title           string `json:"title"`
-	Description     string `json:"description"`
+	Language        string       `json:"language"`
+	Id              string       `json:"id"`
+	InputNameDay    string       `json:"input_name_day"`
+	InputNameMonth  string       `json:"input_name_month"`
+	InputNameYear   string       `json:"input_name_year"`
+	InputValueDay   string       `json:"input_value_day"`
+	InputValueMonth string       `json:"input_value_month"`
+	InputValueYear  string       `json:"input_value_year"`
+	Title           Localisation `json:"title"`
+	Description     Localisation `json:"description"`
 }

--- a/model/input_date.go
+++ b/model/input_date.go
@@ -1,5 +1,6 @@
 package model
 
+// InputDate data
 type InputDate struct {
 	Language        string       `json:"language"`
 	Id              string       `json:"id"`

--- a/model/localisation.go
+++ b/model/localisation.go
@@ -1,0 +1,7 @@
+package model
+
+type Localisation struct {
+	Text      string `json:"text"`
+	LocaleKey string `json:"locale_key"`
+	Plural    int    `json:"plural"`
+}

--- a/model/localisation.go
+++ b/model/localisation.go
@@ -1,5 +1,6 @@
 package model
 
+// Localisation data
 type Localisation struct {
 	Text      string `json:"text"`
 	LocaleKey string `json:"locale_key"`

--- a/model/table_of_contents.go
+++ b/model/table_of_contents.go
@@ -6,10 +6,8 @@ type ContentSection struct {
 }
 
 type TableOfContents struct {
-	AriaLabelLocaliseKey string                    `json:"aria_label_localise_key"`
-	AriaLabel            string                    `json:"aria_label"`
-	TitleLocaliseKey     string                    `json:"title_localise_key"`
-	Title                string                    `json:"title"`
-	Sections             map[string]ContentSection `json:"sections"`
-	DisplayOrder         []string                  `json:"display_order"`
+	AriaLabel    Localisation              `json:"aria_label"`
+	Title        Localisation              `json:"title"`
+	Sections     map[string]ContentSection `json:"sections"`
+	DisplayOrder []string                  `json:"display_order"`
 }

--- a/model/table_of_contents.go
+++ b/model/table_of_contents.go
@@ -1,10 +1,16 @@
 package model
 
+/* ContentSection maps the content details.
+The visible text can be either a 'Localisation.Text' or a 'Localisation.LocaleKey'.
+The 'LocaleKey' has to correspond to the localisation key found in the toml files within assets/locales, otherwise the page will error.
+Plural refers to the plural int used in the toml file.
+*/
 type ContentSection struct {
-	Current bool   `json:"current"`
-	Title   string `json:"title"`
+	Current bool         `json:"current"`
+	Title   Localisation `json:"title"`
 }
 
+// TableOfContents contains the contents of the page
 type TableOfContents struct {
 	AriaLabel    Localisation              `json:"aria_label"`
 	Title        Localisation              `json:"title"`


### PR DESCRIPTION
### What

Combinations of text and locale keys commonly seen on components are a pattern that can be standardised in a new Localisation model.

The Localisation model is defined in `models/localisation.go` and explained in `LOCALISATION.md`.

As this is a breaking change for existing models I'm proposing to tag this as v2.0.0.

Breaking changes:

```
Collapsible
  + Title Localisation
  - Title string
  - LocalisePluralInt int
  - LocaliseKey string

TableOfContents
  + AriaLabel Localisation
  - AriaLabel string
  - AriaLabelLocaliseKey string
  + Title Localisation
  - Title string
  - TitleLocaliseKey string

TableOfContents/ContentSection
  + Title Localisation
  - Title string

InputDate
  + Title Localisation
  - Title string
  + Description Localisation
  - Description string
```

### How to review

Review code for structure and approach

### Who can review

Frontend Go / Design System developers
