### PR TITLE
Fix/banner with spacing tool

### DIFF
--- a/assets/templates/partials/banners/census.tmpl
+++ b/assets/templates/partials/banners/census.tmpl
@@ -2,7 +2,7 @@
 <div class="promo__background--plum-gradient">
     <div class="wrapper">
         <div class="banner--half-padding">
-            <p class="margin-top--0 margin-bottom--0 padding-bottom--0 padding-top--0 flex flex-wrap-wrap banner--vertical-center">
+            <span class="margin-top--0 margin-bottom--0 padding-bottom--0 padding-top--0 flex flex-col flex-wrap-wrap banner--vertical-center">
                 {{ if eq .Language "en"  }}
                     <a class="flex" alt="Census 2021" href="/census"><img src="https://cdn.ons.gov.uk/assets/images/census-logo/logo-census-2021-white-landscape.svg" title="Census 2021" class="header__svg-logo margin-right--1" xmlns="http://www.w3.org/2000/svg"
                     focusable="false" width="167" height="32" viewBox="0 0 242 44"/>
@@ -12,7 +12,7 @@
                     focusable="false" width="167" height="32" viewBox="0 0 242 44"/>
                     <a class="margin-top--0 text--white font-size--18 underline-link" href="/census">Dysgwch fwy am y cyfrifiad</a>
                 {{ end }}
-            </p>
+            </span>
         </div>
     </div>
 </div>


### PR DESCRIPTION
### What

Fix banner when using text spacing tool. Image and text should remain left aligned. 
<img width="1038" alt="Screenshot 2022-04-05 at 11 47 08" src="https://user-images.githubusercontent.com/16807393/161737953-7b79b4c9-467e-43c0-9cbf-3e49b58efd00.png">


### How to review

Added `flex-col` so text and image look like this: 
<img width="1138" alt="Screenshot 2022-04-05 at 11 46 46" src="https://user-images.githubusercontent.com/16807393/161738180-8ec66e32-9813-4141-84df-3432ac416e77.png">


### Who can review

Frontend dev
