### PR TITLE
Update Pagination methods with Func prefix; add unit tests

### DIFF
--- a/assets/templates/partials/pagination.tmpl
+++ b/assets/templates/partials/pagination.tmpl
@@ -1,12 +1,12 @@
 {{ $pagination := .Pagination }}
 {{ $language := .Language }}
-{{ $pageCurrentofTotal := $pagination.PhrasePageNOfTotal $pagination.CurrentPage $language }}
-{{ $previousURL := $pagination.PickPreviousURL }}
-{{ $nextURL := $pagination.PickNextURL }}
+{{ $pageCurrentofTotal := $pagination.FuncPhrasePageNOfTotal $pagination.CurrentPage $language }}
+{{ $previousURL := $pagination.FuncPickPreviousURL }}
+{{ $nextURL := $pagination.FuncPickNextURL }}
 {{ if ne $pagination.TotalPages 0 }}
   <nav
     class="ons-pagination"
-    arial-label="{{ $pagination.PhrasePaginationProgress $pageCurrentofTotal $language }}"
+    arial-label="{{ $pagination.FuncPhrasePaginationProgress $pageCurrentofTotal $language }}"
   >
     <div class="ons-pagination__position ons-u-mb-xs">{{ $pageCurrentofTotal }}</div>
     <ul class="ons-pagination__items">
@@ -16,18 +16,18 @@
             href="{{ $previousURL }}"
             class="ons-pagination__link"
             rel="prev"
-            aria-label="{{ $pagination.PhraseGoToPreviousPage $language }}"
+            aria-label="{{ $pagination.FuncPhraseGoToPreviousPage $language }}"
           >
             {{- localise "PaginationPrevious" $language 1 -}}
           </a>
         </li>
       {{ end }}
-      {{ if $pagination.ShowLinkToFirst }}
+      {{ if $pagination.FuncShowLinkToFirst }}
         <li class="ons-pagination__item">
           <a
             href="{{(index $pagination.FirstAndLastPages 0).URL}}"
             class="ons-pagination__link"
-            aria-label="{{ $pagination.PhraseGoToFirstPage $language }}"
+            aria-label="{{ $pagination.FuncPhraseGoToFirstPage $language }}"
           >1</a>
         </li>
         <li class="ons-pagination__item ons-pagination__item--gap">&hellip;</li>
@@ -39,7 +39,7 @@
               href="{{ .URL}}"
               class="ons-pagination__link"
               aria-current="true"
-              aria-label="{{ $pagination.PhraseCurrentPage $pageCurrentofTotal $language }}"
+              aria-label="{{ $pagination.FuncPhraseCurrentPage $pageCurrentofTotal $language }}"
             >
               {{- .PageNumber -}}
             </a>
@@ -49,20 +49,20 @@
             <a
               href="{{ .URL}}"
               class="ons-pagination__link"
-              aria-label="{{ $pagination.PhrasePageNOfTotal .PageNumber $language }}"
+              aria-label="{{ $pagination.FuncPhrasePageNOfTotal .PageNumber $language }}"
             >
               {{-  .PageNumber -}}
             </a>
           </li>
         {{ end }}
       {{ end }}
-      {{ if $pagination.ShowLinkToLast }}
+      {{ if $pagination.FuncShowLinkToLast }}
         <li class="ons-pagination__item ons-pagination__item--gap">&hellip;</li>
         <li class="ons-pagination__item">
           <a
             href="{{(index $pagination.FirstAndLastPages 1).URL}}"
             class="ons-pagination__link"
-            aria-label="{{ $pagination.PhraseGoToLastPage $language }}"
+            aria-label="{{ $pagination.FuncPhraseGoToLastPage $language }}"
           >
             {{- $pagination.TotalPages -}}
           </a>
@@ -74,7 +74,7 @@
             href="{{ $nextURL }}"
             class="ons-pagination__link"
             rel="next"
-            aria-label="{{ $pagination.PhraseGoToNextPage $language }}"
+            aria-label="{{ $pagination.FuncPhraseGoToNextPage $language }}"
           >
             {{- localise "PaginationNext" $language 1 -}}
           </a>

--- a/model/pagination.go
+++ b/model/pagination.go
@@ -23,20 +23,20 @@ type PageToDisplay struct {
 }
 
 // Produces a string of the form "Page 1 of 10"
-func (pagination Pagination) PhrasePageNOfTotal(n int, language string) string {
+func (pagination Pagination) FuncPhrasePageNOfTotal(n int, language string) string {
 	phrasePage := helper.Localise("PaginationPage", language, 1)
 	phraseOf := helper.Localise("PaginationOf", language, 1)
 	return fmt.Sprintf("%s %d %s %d", phrasePage, n, phraseOf, pagination.TotalPages)
 }
 
 // Produces a string of the form "Pagination (Page 1 of 10)"
-func (pagination Pagination) PhrasePaginationProgress(progress, language string) string {
+func (pagination Pagination) FuncPhrasePaginationProgress(progress, language string) string {
 	phrasePagination := helper.Localise("Pagination", language, 1)
 	return fmt.Sprintf("%s (%s)", phrasePagination, progress)
 }
 
 // Produces a string of the form "Go to the previous page (Page 4)"
-func (pagination Pagination) PhraseGoToPreviousPage(language string) string {
+func (pagination Pagination) FuncPhraseGoToPreviousPage(language string) string {
 	phrasePage := helper.Localise("PaginationPage", language, 1)
 	phraseGoPrevious := helper.Localise("PaginationGoPrevious", language, 1)
 	pageNumber := pagination.CurrentPage - 1
@@ -44,7 +44,7 @@ func (pagination Pagination) PhraseGoToPreviousPage(language string) string {
 }
 
 // Produces a string of the form "Go to the next page (Page 6)"
-func (pagination Pagination) PhraseGoToNextPage(language string) string {
+func (pagination Pagination) FuncPhraseGoToNextPage(language string) string {
 	phrasePage := helper.Localise("PaginationPage", language, 1)
 	phraseGoNext := helper.Localise("PaginationGoNext", language, 1)
 	pageNumber := pagination.CurrentPage + 1
@@ -52,26 +52,26 @@ func (pagination Pagination) PhraseGoToNextPage(language string) string {
 }
 
 // Produces a string of the form "Go to the first page (Page 1)"
-func (pagination Pagination) PhraseGoToFirstPage(language string) string {
+func (pagination Pagination) FuncPhraseGoToFirstPage(language string) string {
 	phrasePage := helper.Localise("PaginationPage", language, 1)
 	phraseGoFirst := helper.Localise("PaginationGoFirst", language, 1)
 	return fmt.Sprintf("%s (%s 1)", phraseGoFirst, phrasePage)
 }
 
 // Produces a string of the form "Current page (Page 5 of 10)"
-func (pagination Pagination) PhraseCurrentPage(progress, language string) string {
+func (pagination Pagination) FuncPhraseCurrentPage(progress, language string) string {
 	phrasePagination := helper.Localise("PaginationCurrentPage", language, 1)
 	return fmt.Sprintf("%s (%s)", phrasePagination, progress)
 }
 
 // Produces a string of the form "Go to the last page (Page 10)"
-func (pagination Pagination) PhraseGoToLastPage(language string) string {
+func (pagination Pagination) FuncPhraseGoToLastPage(language string) string {
 	phrasePage := helper.Localise("PaginationPage", language, 1)
 	phraseGoLast := helper.Localise("PaginationGoLast", language, 1)
 	return fmt.Sprintf("%s (%s %d)", phraseGoLast, phrasePage, pagination.TotalPages)
 }
 
-func (pagination Pagination) PickPreviousURL() string {
+func (pagination Pagination) FuncPickPreviousURL() string {
 	for _, pageToDisplay := range pagination.PagesToDisplay {
 		if pageToDisplay.PageNumber == pagination.CurrentPage-1 {
 			return pageToDisplay.URL
@@ -81,7 +81,7 @@ func (pagination Pagination) PickPreviousURL() string {
 	return "#"
 }
 
-func (pagination Pagination) PickNextURL() string {
+func (pagination Pagination) FuncPickNextURL() string {
 	for _, pageToDisplay := range pagination.PagesToDisplay {
 		if pageToDisplay.PageNumber == pagination.CurrentPage+1 {
 			return pageToDisplay.URL
@@ -91,11 +91,11 @@ func (pagination Pagination) PickNextURL() string {
 	return "#"
 }
 
-func (pagination Pagination) ShowLinkToFirst() bool {
+func (pagination Pagination) FuncShowLinkToFirst() bool {
 	return pagination.PagesToDisplay[0].PageNumber > 1
 }
 
-func (pagination Pagination) ShowLinkToLast() bool {
+func (pagination Pagination) FuncShowLinkToLast() bool {
 	lastPage := len(pagination.PagesToDisplay) - 1
 	return pagination.PagesToDisplay[lastPage].PageNumber != pagination.TotalPages
 }

--- a/model/pagination_test.go
+++ b/model/pagination_test.go
@@ -1,0 +1,183 @@
+package model_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ONSdigital/dp-renderer/helper"
+	"github.com/ONSdigital/dp-renderer/model"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func mockPaginationLocales(name string) ([]byte, error) {
+	locale := []string{
+		"[Pagination]",
+		"one = \"Pagination\"",
+		"[PaginationPage]",
+		"one = \"Page\"",
+		"[PaginationOf]",
+		"one = \"of\"",
+		"[PaginationGoPrevious]",
+		"one = \"Go to the previous page\"",
+		"[PaginationGoFirst]",
+		"one = \"Go to the first page\"",
+		"[PaginationCurrentPage]",
+		"one = \"Current page\"",
+		"[PaginationGoLast]",
+		"one = \"Go to the last page\"",
+		"[PaginationGoNext]",
+		"one = \"Go to the next page\"",
+	}
+	return []byte(strings.Join(locale, "\n")), nil
+}
+
+func TestPagination(t *testing.T) {
+	helper.InitialiseLocalisationsHelper(mockPaginationLocales)
+
+	Convey("FuncPhrasePageNOfTotal", t, func() {
+		Convey("Should render a string like 'Page 1 of 10'", func() {
+			pagination := model.Pagination{
+				TotalPages: 10,
+			}
+			So(pagination.FuncPhrasePageNOfTotal(1, "en"), ShouldEqual, "Page 1 of 10")
+		})
+	})
+
+	Convey("FuncPhrasePaginationProgress", t, func() {
+		Convey("Should render a progress string in parentheses", func() {
+			pagination := model.Pagination{}
+			So(pagination.FuncPhrasePaginationProgress("progress", "en"), ShouldEqual, "Pagination (progress)")
+		})
+	})
+
+	Convey("FuncPhraseGoToPreviousPage", t, func() {
+		Convey("Should render direction with page number in parentheses", func() {
+			pagination := model.Pagination{
+				CurrentPage: 2,
+			}
+			So(pagination.FuncPhraseGoToPreviousPage("en"), ShouldEqual, "Go to the previous page (Page 1)")
+		})
+	})
+
+	Convey("FuncPhraseGoToNextPage", t, func() {
+		Convey("Should render direction with page number in parentheses", func() {
+			pagination := model.Pagination{
+				CurrentPage: 2,
+			}
+			So(pagination.FuncPhraseGoToNextPage("en"), ShouldEqual, "Go to the next page (Page 3)")
+		})
+	})
+
+	Convey("FuncPhraseGoToFirstPage", t, func() {
+		Convey("Should render direction with page number in parentheses", func() {
+			pagination := model.Pagination{}
+			So(pagination.FuncPhraseGoToFirstPage("en"), ShouldEqual, "Go to the first page (Page 1)")
+		})
+	})
+
+	Convey("FuncPhraseCurrentPage", t, func() {
+		Convey("Should render a progress string in parentheses", func() {
+			pagination := model.Pagination{}
+			So(pagination.FuncPhraseCurrentPage("progress", "en"), ShouldEqual, "Current page (progress)")
+		})
+	})
+
+	Convey("FuncPhraseGoToLastPage", t, func() {
+		Convey("Should render direction with page number in parentheses", func() {
+			pagination := model.Pagination{
+				TotalPages: 10,
+			}
+			So(pagination.FuncPhraseGoToLastPage("en"), ShouldEqual, "Go to the last page (Page 10)")
+		})
+	})
+
+	Convey("FuncPickPreviousURL", t, func() {
+		Convey("Should pick the URL of the previous page", func() {
+			pagination := model.Pagination{
+				PagesToDisplay: []model.PageToDisplay{
+					{PageNumber: 1, URL: "previous"},
+					{PageNumber: 2, URL: "current"},
+				},
+				CurrentPage: 2,
+			}
+			So(pagination.FuncPickPreviousURL(), ShouldEqual, "previous")
+		})
+
+		Convey("Should return an empty fragment when the previous page lies outside the display window", func() {
+			pagination := model.Pagination{
+				PagesToDisplay: []model.PageToDisplay{
+					{PageNumber: 1, URL: "current"},
+					{PageNumber: 2, URL: "2"},
+				},
+				CurrentPage: 1,
+			}
+			So(pagination.FuncPickPreviousURL(), ShouldEqual, "#")
+		})
+	})
+
+	Convey("FuncPickNextURL", t, func() {
+		Convey("Should pick the URL of the next page", func() {
+			pagination := model.Pagination{
+				PagesToDisplay: []model.PageToDisplay{
+					{PageNumber: 1, URL: "current"},
+					{PageNumber: 2, URL: "next"},
+				},
+				CurrentPage: 1,
+			}
+			So(pagination.FuncPickNextURL(), ShouldEqual, "next")
+		})
+
+		Convey("Should return an empty fragment when the next page lies outside the display window", func() {
+			pagination := model.Pagination{
+				PagesToDisplay: []model.PageToDisplay{
+					{PageNumber: 1, URL: "1"},
+					{PageNumber: 2, URL: "current"},
+				},
+				CurrentPage: 2,
+			}
+			So(pagination.FuncPickNextURL(), ShouldEqual, "#")
+		})
+	})
+
+	Convey("FuncShowLinkToFirst", t, func() {
+		Convey("Should be false when the display window begins with the first page", func() {
+			pagination := model.Pagination{
+				PagesToDisplay: []model.PageToDisplay{
+					{PageNumber: 1, URL: ""},
+				},
+			}
+			So(pagination.FuncShowLinkToFirst(), ShouldBeFalse)
+		})
+
+		Convey("Should be true otherwise", func() {
+			pagination := model.Pagination{
+				PagesToDisplay: []model.PageToDisplay{
+					{PageNumber: 2, URL: ""},
+				},
+			}
+			So(pagination.FuncShowLinkToFirst(), ShouldBeTrue)
+		})
+	})
+
+	Convey("FuncShowLinkToLast", t, func() {
+		Convey("Should be false when the display window ends with the last page", func() {
+			pagination := model.Pagination{
+				PagesToDisplay: []model.PageToDisplay{
+					{PageNumber: 10, URL: ""},
+				},
+				TotalPages: 10,
+			}
+			So(pagination.FuncShowLinkToLast(), ShouldBeFalse)
+		})
+
+		Convey("Should be true otherwise", func() {
+			pagination := model.Pagination{
+				PagesToDisplay: []model.PageToDisplay{
+					{PageNumber: 9, URL: ""},
+				},
+				TotalPages: 10,
+			}
+			So(pagination.FuncShowLinkToLast(), ShouldBeTrue)
+		})
+	})
+}


### PR DESCRIPTION
### What

- Pagination methods renamed from `NameOfMethod` to `FuncNameOfMethod`
- Pagination methods now unit tested

### How to review

Sanity check

### Who can review

Go developers
