### PR TITLE
Feature/back to UI component

### DIFF
--- a/PATTERNS.md
+++ b/PATTERNS.md
@@ -45,9 +45,11 @@ e.g.
 
 ```go
 p.Collapsible = coreModel.Collapsible{
-  // You can either use a localisation key or populate the `Title` string
-  LocaliseKey:       "VariablesExplanation",
-  LocalisePluralInt: 4,
+  // You can either use a localisation key or populate the `Text` string
+  Title: coreModel.Localisation{
+    LocaleKey: "VariablesExplanation",
+    Plural:    4,
+  },
   CollapsibleItems: []coreModel.CollapsibleItem{
    {
     Subheading: "This is a subheading",
@@ -259,3 +261,28 @@ page.PublicationDate = InputDate{
 
 All translations live in `assets/locales/core.<language>.toml` and
 are prefixed with `InputDate`.
+
+## BackTo
+
+To instatiate the 'back to' UI component in your service:
+
+- In the `mapper.go` file in your service, populate the relevant fields:
+
+```go
+p.BackTo = coreModel.BackTo{
+  Text: coreModel.Localisation{
+    LocaleKey: "BackToContents",
+    Plural:    4,
+  },
+  AnchorFragment: "toc",
+}
+```
+
+- In the template file within your service, reference the
+`back-to.tmpl` file:
+
+```tmpl
+<div>Some html...</div>
+{{ template "partials/back-to" . }}
+<div>Some more html</div>
+```

--- a/assets/locales/core.cy.toml
+++ b/assets/locales/core.cy.toml
@@ -519,3 +519,9 @@ one = "Blaenorol"
 [PaginationNext]
 description = "Next"
 one = "Nesaf"
+
+# Back to
+[BackToContents]
+description = "Back to contents"
+one = "Back to content"
+other = "Back to contents"

--- a/assets/locales/core.en.toml
+++ b/assets/locales/core.en.toml
@@ -514,3 +514,9 @@ one = "Month"
 [InputDateYear]
 description = "Year"
 one = "Year"
+
+# Back to
+[BackToContents]
+description = "Back to contents"
+one = "Back to content"
+other = "Back to contents"

--- a/assets/templates/icons/arrow-up.tmpl
+++ b/assets/templates/icons/arrow-up.tmpl
@@ -1,0 +1,14 @@
+<svg
+    class="ons-svg-icon ons-u-mr-xs"
+    width="16"
+    height="17"
+    viewBox="0 0 16 17"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    focusable="false"
+    aria-hidden="true"
+    role="presentation">
+    <path
+        d="M0 8.07275L1.41 9.48275L7 3.90275V16.0728H9V3.90275L14.58 9.49275L16 8.07275L8 0.0727539L0 8.07275Z"
+        fill="currentColor"></path>
+</svg>

--- a/assets/templates/partials/back-to.tmpl
+++ b/assets/templates/partials/back-to.tmpl
@@ -1,0 +1,9 @@
+{{/* See PATTERNS.md for usage instructions */}}
+<div class="ons-back-to">
+    <a href="#{{- .BackTo.AnchorFragment -}}" class="ons-back-to__link">
+        <span class="ons-back-to__icon">
+            {{- template "icons/arrow-up" . -}}
+        </span>
+        {{- .BackTo.Text.FuncLocalise .Language -}}
+    </a>
+</div>

--- a/model/back_to.go
+++ b/model/back_to.go
@@ -1,0 +1,10 @@
+package model
+
+/* BackTo maps the back to component.
+AnchorFragment refers to the anchor fragment on the page to link to, leave empty to display the default '#'.
+Text refers to the display text that can be either a 'Localisation.Text' or a 'Localisation.LocaleKey'.
+*/
+type BackTo struct {
+	AnchorFragment string       `json:"anchor_fragment"`
+	Text           Localisation `json:"text"`
+}

--- a/model/page.go
+++ b/model/page.go
@@ -28,6 +28,7 @@ type Page struct {
 	Collapsible                      Collapsible     `json:"collapsible"`
 	Pagination                       Pagination      `json:"pagination"`
 	TableOfContents                  TableOfContents `json:"table_of_contents"`
+	BackTo                           BackTo          `json:"back_to"`
 }
 
 // FeatureFlags contains toggles for certain features on the website
@@ -35,7 +36,7 @@ type FeatureFlags struct {
 	HideCookieBanner       bool   `json:"hide_cookie_banner"`
 	ONSDesignSystemVersion string `json:"ons_design_system_version"`
 	SixteensVersion        string `json:"legacy_sixteens_version"`
-	EnableCensusTile       bool    `json:"enable_census_tile"`
+	EnableCensusTile       bool   `json:"enable_census_tile"`
 	EnableCensusBanner     bool   `json:"enable_census_banner"`
 }
 


### PR DESCRIPTION
### What

Created 'back to' UI component
Minor documentation update and formatting in `models.go`

### How to review

- Sense check
- Review image ⬇️ with [design](https://www.figma.com/proto/JLlYEPtSK2NxrBTVkxLCJB/ONS-DP-GetDataUI?page-id=4065%3A253889&node-id=4072%3A258425&viewport=485%2C48%2C0.25&scaling=scale-down&starting-point-node-id=4065%3A253890) or design image below ⬇️ 
- _Optionally_ you can pull this branch, the latest [dp-design-system](https://github.com/ONSdigital/dp-design-system) and using your favourite frontend service, instantiate the 'back-to' component as per the instructions in the PATTERNS.md or call me 🤙 and I can show you it working in the [dp-frontend-dataset-controller](https://github.com/ONSdigital/dp-frontend-dataset-controller)

#### Images
##### In frontend service
<img width="213" alt="back to component" src="https://user-images.githubusercontent.com/19624419/167872924-7e7da419-772b-4a13-a109-6a97628d1c16.png">

##### From design
![image](https://user-images.githubusercontent.com/19624419/167874403-b1580694-6070-46c8-aae0-cf59a5c8d54d.png)

### Who can review

Frontend dev
