### PR TITLE
Localise months and am/pm in ONSDatePattern timestamps

### DIFF
--- a/assets/locales/core.cy.toml
+++ b/assets/locales/core.cy.toml
@@ -598,3 +598,60 @@ one = "See correction"
 [ScheduledUpdate]
 description = "Scheduled update"
 one = "Scheduled update/revision"
+
+# Timestamps
+[TimestampTwelveHouram]
+description = "am"
+one = "am"
+
+[TimestampTwelveHourpm]
+description = "pm"
+one = "pm"
+
+[TimestampMonthJanuary]
+description = "January"
+one = "Ionawr"
+
+[TimestampMonthFebruary]
+description = "February"
+one = "Chwefror"
+
+[TimestampMonthMarch]
+description = "March"
+one = "Mawrth"
+
+[TimestampMonthApril]
+description = "April"
+one = "Ebrill"
+
+[TimestampMonthMay]
+description = "May"
+one = "Mai"
+
+[TimestampMonthJune]
+description = "June"
+one = "Mehefin"
+
+[TimestampMonthJuly]
+description = "July"
+one = "Gorffennaf"
+
+[TimestampMonthAugust]
+description = "August"
+one = "Awst"
+
+[TimestampMonthSeptember]
+description = "September"
+one = "Medi"
+
+[TimestampMonthOctober]
+description = "October"
+one = "Hydref"
+
+[TimestampMonthNovember]
+description = "November"
+one = "Tachwedd"
+
+[TimestampMonthDecember]
+description = "December"
+one = "Rhagfyr"

--- a/assets/locales/core.en.toml
+++ b/assets/locales/core.en.toml
@@ -593,3 +593,60 @@ one = "See correction"
 [ScheduledUpdate]
 description = "Scheduled update"
 one = "Scheduled update/revision"
+
+# Timestamps
+[TimestampTwelveHouram]
+description = "am"
+one = "am"
+
+[TimestampTwelveHourpm]
+description = "pm"
+one = "pm"
+
+[TimestampMonthJanuary]
+description = "January"
+one = "January"
+
+[TimestampMonthFebruary]
+description = "February"
+one = "February"
+
+[TimestampMonthMarch]
+description = "March"
+one = "March"
+
+[TimestampMonthApril]
+description = "April"
+one = "April"
+
+[TimestampMonthMay]
+description = "May"
+one = "May"
+
+[TimestampMonthJune]
+description = "June"
+one = "June"
+
+[TimestampMonthJuly]
+description = "July"
+one = "July"
+
+[TimestampMonthAugust]
+description = "August"
+one = "August"
+
+[TimestampMonthSeptember]
+description = "September"
+one = "September"
+
+[TimestampMonthOctober]
+description = "October"
+one = "October"
+
+[TimestampMonthNovember]
+description = "November"
+one = "November"
+
+[TimestampMonthDecember]
+description = "December"
+one = "December"

--- a/helper/date_format_test.go
+++ b/helper/date_format_test.go
@@ -1,6 +1,7 @@
 package helper_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/ONSdigital/dp-renderer/helper"
@@ -37,14 +38,61 @@ func TestDateFormatYYYYMMDDNoSlash(t *testing.T) {
 	})
 }
 
+var cyLocale = []string{
+	"[TimestampMonthMay]",
+	"one = \"Mai\"",
+	"[TimestampMonthAugust]",
+	"one = \"Awst\"",
+	"[TimestampMonthDecember]",
+	"one = \"Rhagfyr\"",
+	"[TimestampTwelveHouram]",
+	"one = \"am\"",
+	"[TimestampTwelveHourpm]",
+	"one = \"pm\"",
+}
+
+var enLocale = []string{
+	"[TimestampMonthMay]",
+	"one = \"May\"",
+	"[TimestampMonthAugust]",
+	"one = \"August\"",
+	"[TimestampMonthDecember]",
+	"one = \"December\"",
+	"[TimestampTwelveHouram]",
+	"one = \"am\"",
+	"[TimestampTwelveHourpm]",
+	"one = \"pm\"",
+}
+
+func mockTimestampAssetFunction(name string) ([]byte, error) {
+	if strings.Contains(name, ".cy.toml") {
+		return []byte(strings.Join(cyLocale, "\n")), nil
+	}
+	return []byte(strings.Join(enLocale, "\n")), nil
+}
+
 func TestDateTimeOnsDatePatternFormat(t *testing.T) {
+	helper.InitialiseLocalisationsHelper(mockTimestampAssetFunction)
+
 	Convey("Date format returns human readable string", t, func() {
-		So(helper.DateTimeOnsDatePatternFormat("2019-08-03T00:00:00.000Z"), ShouldEqual, "3 August 2019 1:00am")  // BST
-		So(helper.DateTimeOnsDatePatternFormat("2019-08-15T00:00:00.000Z"), ShouldEqual, "15 August 2019 1:00am") // BST
-		So(helper.DateTimeOnsDatePatternFormat("2019-05-21T23:00:00.000Z"), ShouldEqual, "22 May 2019 12:00am")   // BST
-		So(helper.DateTimeOnsDatePatternFormat("2019-12-21T23:00:00.000Z"), ShouldEqual, "21 December 2019 11:00pm")
-		So(helper.DateTimeOnsDatePatternFormat("2019-08-15"), ShouldEqual, "2019-08-15") // failed to parse, so returns arg value
-		So(helper.DateTimeOnsDatePatternFormat(""), ShouldEqual, "")
+		So(helper.DateTimeOnsDatePatternFormat("2019-08-03T00:00:00.000Z", ""), ShouldEqual, "3 August 2019 1:00am")  // BST
+		So(helper.DateTimeOnsDatePatternFormat("2019-08-15T00:00:00.000Z", ""), ShouldEqual, "15 August 2019 1:00am") // BST
+		So(helper.DateTimeOnsDatePatternFormat("2019-05-21T23:00:00.000Z", ""), ShouldEqual, "22 May 2019 12:00am")   // BST
+		So(helper.DateTimeOnsDatePatternFormat("2019-12-21T23:00:00.000Z", ""), ShouldEqual, "21 December 2019 11:00pm")
+		So(helper.DateTimeOnsDatePatternFormat("2019-08-15", ""), ShouldEqual, "2019-08-15") // failed to parse, so returns arg value
+		So(helper.DateTimeOnsDatePatternFormat("", ""), ShouldEqual, "")
+	})
+
+	Convey("Date is localised", t, func() {
+		So(helper.DateTimeOnsDatePatternFormat("2019-08-03T00:00:00.000Z", "en"), ShouldEqual, "3 August 2019 1:00am")  // BST
+		So(helper.DateTimeOnsDatePatternFormat("2019-08-15T00:00:00.000Z", "en"), ShouldEqual, "15 August 2019 1:00am") // BST
+		So(helper.DateTimeOnsDatePatternFormat("2019-05-21T23:00:00.000Z", "en"), ShouldEqual, "22 May 2019 12:00am")   // BST
+		So(helper.DateTimeOnsDatePatternFormat("2019-12-21T23:00:00.000Z", "en"), ShouldEqual, "21 December 2019 11:00pm")
+
+		So(helper.DateTimeOnsDatePatternFormat("2019-08-03T00:00:00.000Z", "cy"), ShouldEqual, "3 Awst 2019 1:00am")  // BST
+		So(helper.DateTimeOnsDatePatternFormat("2019-08-15T00:00:00.000Z", "cy"), ShouldEqual, "15 Awst 2019 1:00am") // BST
+		So(helper.DateTimeOnsDatePatternFormat("2019-05-21T23:00:00.000Z", "cy"), ShouldEqual, "22 Mai 2019 12:00am") // BST
+		So(helper.DateTimeOnsDatePatternFormat("2019-12-21T23:00:00.000Z", "cy"), ShouldEqual, "21 Rhagfyr 2019 11:00pm")
 	})
 }
 


### PR DESCRIPTION
### What

Localise months and am/pm in ONSDatePattern timestamps

English

<img width="954" alt="Screenshot 2022-05-27 at 17 57 31" src="https://user-images.githubusercontent.com/912770/170749931-1fa4fa86-2bec-4a08-93ba-74252b21b8a7.png">

Welsh

<img width="972" alt="Screenshot 2022-05-27 at 17 57 13" src="https://user-images.githubusercontent.com/912770/170750065-78cd8fee-5e82-49ac-aafa-cbe0123740f1.png">

### How to review

- Sense check
- Run tests

### Who can review

Go developers
