### PR TITLE
add `noindex` and `canonical` tag for search pages

### DIFF
--- a/assets/templates/main.tmpl
+++ b/assets/templates/main.tmpl
@@ -10,7 +10,7 @@
       - {{ localise "OfficeForNationalStatistics" .Language 1 }}
     </title>
     
-    {{if eq .Metadata.Title "Home" }}
+    {{ if eq .Metadata.Title "Home" }}
       <meta name="description" content="{{ localise "HomepageDescription" .Language 1 }}"> 
     {{ else }}
       <meta name="description" content="{{ .Metadata.Description }}">

--- a/assets/templates/main.tmpl
+++ b/assets/templates/main.tmpl
@@ -9,13 +9,23 @@
       {{- end }}
       - {{ localise "OfficeForNationalStatistics" .Language 1 }}
     </title>
-    {{if eq .Metadata.Title "Home"}}<meta name="description" content="{{ localise "HomepageDescription" .Language 1 }}"> {{ else }}<meta name="description" content="{{ .Metadata.Description}}">{{ end }}
+    
+    {{if eq .Metadata.Title "Home"}}
+      <meta name="description" content="{{ localise "HomepageDescription" .Language 1 }}"> 
+    {{ else }}
+      <meta name="description" content="{{ .Metadata.Description}}">
+    {{ end }}
+
     <meta charset="utf-8"/>
     <meta content="width=device-width,initial-scale=1.0,user-scalable=1" name="viewport">
     <meta name="format-detection" content="telephone=no">
     <meta name="theme-color" content="#58595B">
     <meta name="apple-mobile-web-app-status-bar-style" content="#58595B">
-    {{ if .Metadata.ServiceName }}<meta name="ons:service" content="{{ .Metadata.ServiceName}}">{{ end }}
+    
+    {{ if .Metadata.ServiceName }}
+      <meta name="ons:service" content="{{ .Metadata.ServiceName}}">
+    {{ end }}
+    
     {{ if .FeatureFlags.SixteensVersion }}
       {{ if eq .SiteDomain "localhost" }}
         <link rel="stylesheet" href="http://localhost:9000/dist/css/main.css">
@@ -25,12 +35,26 @@
     {{ else }}
       <link rel="stylesheet" href="{{ .PatternLibraryAssetsPath }}/css/main.css">
     {{ end }}
+    
     {{ if .HasJSONLD -}}
       {{ template "partials/json-ld/base" . }}
     {{- end }}
+
+    {{ if eq .Type "search"}}
+
+      {{/* if search a/b testing is at 100% then noindex tag else canonical tag */}}
+      {{ if .SearchNoIndexEnabled }}
+        <meta name="robots" content="noindex">
+      {{ else }}
+        <link rel="canonical" href={{ concatenateStrings "https://www." .SiteDomain "/search?q=" .Data.Query }}>
+      {{ end }}
+
+    {{ end }}
+
     {{ if eq .Metadata.Title "Feedback" }}
       <link rel="canonical" href={{ concatenateStrings "https://www." .SiteDomain "/feedback" }}>
     {{ end }}
+
     {{ template "partials/gtm-data-layer" . }}
     <!-- Google Tag Manager -->
     <script>
@@ -49,6 +73,7 @@
     </script>
     <!-- End Google Tag Manager -->
   </head>
+  
   <body class="page-type--{{ .Type }}">
     <script>
       document.body.className = (
@@ -56,6 +81,7 @@
         ? document.body.className + ' js js-enabled'
         : 'js js-enabled');
     </script>
+    
     <!-- Google Tag Manager (noscript) -->
     <noscript>
       <iframe
@@ -65,6 +91,7 @@
         style="display:none;visibility:hidden"></iframe>
     </noscript>
     <!-- End Google Tag Manager (noscript) -->
+    
     {{ if not .FeatureFlags.SixteensVersion }}
       <div class="ons-page">
         <div class="ons-page__content">
@@ -91,6 +118,7 @@
         <script defer src="/js/app.js"></script>
       {{ end }}
     {{ end }}
+    
     {{ partial "scripts" }}
   </body>
 </html>

--- a/assets/templates/main.tmpl
+++ b/assets/templates/main.tmpl
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{if .Language }}{{ .Language }}{{ else }}en{{ end }}" xml:lang="{{ if .Language }}{{ .Language }}{{ else }}en{{ end }}">
+<html lang="{{ if .Language }}{{ .Language }}{{ else }}en{{ end }}" xml:lang="{{ if .Language }}{{ .Language }}{{ else }}en{{ end }}">
   <head>
     <title>
       {{ if .Error.Title }}
@@ -10,10 +10,10 @@
       - {{ localise "OfficeForNationalStatistics" .Language 1 }}
     </title>
     
-    {{if eq .Metadata.Title "Home"}}
+    {{if eq .Metadata.Title "Home" }}
       <meta name="description" content="{{ localise "HomepageDescription" .Language 1 }}"> 
     {{ else }}
-      <meta name="description" content="{{ .Metadata.Description}}">
+      <meta name="description" content="{{ .Metadata.Description }}">
     {{ end }}
 
     <meta charset="utf-8"/>
@@ -23,7 +23,7 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="#58595B">
     
     {{ if .Metadata.ServiceName }}
-      <meta name="ons:service" content="{{ .Metadata.ServiceName}}">
+      <meta name="ons:service" content="{{ .Metadata.ServiceName }}">
     {{ end }}
     
     {{ if .FeatureFlags.SixteensVersion }}
@@ -40,7 +40,7 @@
       {{ template "partials/json-ld/base" . }}
     {{- end }}
 
-    {{ if eq .Type "search"}}
+    {{ if eq .Type "search" }}
 
       {{/* if search a/b testing is at 100% then noindex tag else canonical tag */}}
       {{ if .SearchNoIndexEnabled }}
@@ -96,12 +96,12 @@
       <div class="ons-page">
         <div class="ons-page__content">
         {{ end }}
-        {{ if (ne .FeatureFlags.HideCookieBanner true)}}
+        {{ if (ne .FeatureFlags.HideCookieBanner true) }}
           {{ template "partials/banners/cookies" . }}
         {{ end }}
         {{ template "partials/header" . }}
         <main id="main" role="main" tabindex="-1">
-          {{yield}}
+          {{ yield }}
         </main>
         {{ template "partials/footer" . }}
         {{ if not .FeatureFlags.SixteensVersion }}


### PR DESCRIPTION
### What
**Describe what you have changed and why.**
- Extend dp-renderer library main.tmpl to include:
  - noindex tag when a/b testing is at 100%, so this means 100% users going to new search
  - canonical tag when a/b testing is not 100%, so this is when some users are still going to old search
- Format `main.tmpl` to be more readable

### How to review
**Describe the steps required to test the changes.**
- Check if the code changes make sense

### Who can review
**Describe who worked on the changes, so that other people can review.**
- Anyone