### PR TITLE
Create sharing links

### DIFF
--- a/model/share_link.go
+++ b/model/share_link.go
@@ -1,0 +1,94 @@
+package model
+
+import (
+	"fmt"
+	"net/url"
+)
+
+type SocialType int
+
+const (
+	SocialUnknown SocialType = iota
+	SocialEmail
+	SocialFacebook
+	SocialLinkedin
+	SocialTwitter
+)
+
+type ShareLink struct {
+	Type               SocialType
+	Url                string
+	RequiresJavaScript bool
+}
+
+func (s SocialType) String() string {
+	var result string
+	switch s {
+	case SocialUnknown:
+		result = "unknown"
+	case SocialEmail:
+		result = "email"
+	case SocialFacebook:
+		result = "facebook"
+	case SocialLinkedin:
+		result = "linkedin"
+	case SocialTwitter:
+		result = "twitter"
+	}
+	return result
+}
+
+func emailLink(title, target string) ShareLink {
+	url := fmt.Sprintf("mailto:?subject=%s&body=%s%%0A%s", title, title, target)
+	return ShareLink{
+		Type:               SocialEmail,
+		Url:                url,
+		RequiresJavaScript: false,
+	}
+}
+
+func facebookLink(target string) ShareLink {
+	url := fmt.Sprintf("https://www.facebook.com/sharer.php?u=%s", target)
+	return ShareLink{
+		Type:               SocialFacebook,
+		Url:                url,
+		RequiresJavaScript: true,
+	}
+}
+
+func linkedinLink(target string) ShareLink {
+	url := fmt.Sprintf("https://www.linkedin.com/sharing/share-offsite/?url=%s", target)
+	return ShareLink{
+		Type:               SocialLinkedin,
+		Url:                url,
+		RequiresJavaScript: true,
+	}
+}
+
+func twitterLink(title, target string) ShareLink {
+	url := fmt.Sprintf("https://twitter.com/intent/tweet?text=%s&url=%s", title, target)
+	return ShareLink{
+		Type:               SocialTwitter,
+		Url:                url,
+		RequiresJavaScript: true,
+	}
+}
+
+func (s SocialType) CreateLink(title, target string) ShareLink {
+	var result ShareLink
+	escTitle := url.QueryEscape(title)
+	escTarget := url.QueryEscape(target)
+
+	switch s {
+	case SocialEmail:
+		result = emailLink(escTitle, escTarget)
+	case SocialFacebook:
+		result = facebookLink(escTarget)
+	case SocialLinkedin:
+		result = linkedinLink(escTarget)
+	case SocialTwitter:
+		result = twitterLink(escTitle, escTarget)
+	}
+
+	return result
+}

--- a/model/share_link.go
+++ b/model/share_link.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 )
 
+// Enumerates known social types that allow sharing a resource via a link URL
 type SocialType int
 
 const (
@@ -15,12 +16,14 @@ const (
 	SocialTwitter
 )
 
+// Represents an instance of a link URL for a specific shared resource
 type ShareLink struct {
 	Type               SocialType
 	Url                string
 	RequiresJavaScript bool
 }
 
+// Stringer interface
 func (s SocialType) String() string {
 	var result string
 	switch s {
@@ -74,6 +77,7 @@ func twitterLink(title, target string) ShareLink {
 	}
 }
 
+// Creates a ShareLink from the supplied resource title and target URL
 func (s SocialType) CreateLink(title, target string) ShareLink {
 	var result ShareLink
 	escTitle := url.QueryEscape(title)

--- a/model/share_link_test.go
+++ b/model/share_link_test.go
@@ -1,0 +1,169 @@
+package model_test
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/ONSdigital/dp-renderer/model"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestShareLink(t *testing.T) {
+	Convey("SocialType", t, func() {
+		Convey("Should implement the Stringer interface", func() {
+			So(model.SocialEmail.String(), ShouldEqual, "email")
+		})
+	})
+
+	Convey("CreateLink", t, func() {
+		Convey("SocialUnknown", func() {
+			title := "Test Title"
+			target := "https://www.example.com"
+			shareLink := model.SocialUnknown.CreateLink(title, target)
+
+			Convey("Should create a link of the specified type", func() {
+				So(shareLink.Type, ShouldEqual, model.SocialUnknown)
+			})
+
+			Convey("Should indicate the medium's dependency on JavaScript", func() {
+				So(shareLink.RequiresJavaScript, ShouldBeFalse)
+			})
+
+			Convey("Should have an empty link", func() {
+				So(shareLink.Url, ShouldEqual, "")
+			})
+		})
+
+		Convey("SocialEmail", func() {
+			title := "Test Title"
+			target := "https://www.example.com"
+			shareLink := model.SocialEmail.CreateLink(title, target)
+
+			Convey("Should create a link of the specified type", func() {
+				So(shareLink.Type, ShouldEqual, model.SocialEmail)
+			})
+
+			Convey("Should indicate the medium's dependency on JavaScript", func() {
+				So(shareLink.RequiresJavaScript, ShouldBeFalse)
+			})
+
+			Convey("Should contain a well formed link", func() {
+				parsedUrl, err := url.Parse(shareLink.Url)
+				So(err, ShouldBeNil)
+				params := parsedUrl.Query()
+
+				Convey("Should create a link with the correct protocol", func() {
+					So(parsedUrl.Scheme, ShouldEqual, "mailto")
+				})
+
+				Convey("Should create a link containing the title", func() {
+					So(params.Get("subject"), ShouldEqual, title)
+				})
+
+				Convey("Should create a link containing the target", func() {
+					So(params.Get("body"), ShouldContainSubstring, target)
+				})
+			})
+		})
+
+		Convey("SocialFacebook", func() {
+			title := "Test Title"
+			target := "https://www.example.com"
+			shareLink := model.SocialFacebook.CreateLink(title, target)
+
+			Convey("Should create a link of the specified type", func() {
+				So(shareLink.Type, ShouldEqual, model.SocialFacebook)
+			})
+
+			Convey("Should indicate the medium's dependency on JavaScript", func() {
+				So(shareLink.RequiresJavaScript, ShouldBeTrue)
+			})
+
+			Convey("Should contain a well formed link", func() {
+				parsedUrl, err := url.Parse(shareLink.Url)
+				So(err, ShouldBeNil)
+				params := parsedUrl.Query()
+
+				Convey("Should create a link with the correct protocol", func() {
+					So(parsedUrl.Scheme, ShouldEqual, "https")
+				})
+
+				Convey("Should create a link with the correct domain", func() {
+					So(parsedUrl.Hostname(), ShouldEqual, "www.facebook.com")
+				})
+
+				Convey("Should create a link containing the target", func() {
+					So(params.Get("u"), ShouldEqual, target)
+				})
+			})
+		})
+
+		Convey("SocialLinkedin", func() {
+			title := "Test Title"
+			target := "https://www.example.com"
+			shareLink := model.SocialLinkedin.CreateLink(title, target)
+
+			Convey("Should create a link of the specified type", func() {
+				So(shareLink.Type, ShouldEqual, model.SocialLinkedin)
+			})
+
+			Convey("Should indicate the medium's dependency on JavaScript", func() {
+				So(shareLink.RequiresJavaScript, ShouldBeTrue)
+			})
+
+			Convey("Should contain a well formed link", func() {
+				parsedUrl, err := url.Parse(shareLink.Url)
+				So(err, ShouldBeNil)
+				params := parsedUrl.Query()
+
+				Convey("Should create a link with the correct protocol", func() {
+					So(parsedUrl.Scheme, ShouldEqual, "https")
+				})
+
+				Convey("Should create a link with the correct domain", func() {
+					So(parsedUrl.Hostname(), ShouldEqual, "www.linkedin.com")
+				})
+
+				Convey("Should create a link containing the target", func() {
+					So(params.Get("url"), ShouldEqual, target)
+				})
+			})
+		})
+
+		Convey("SocialTwitter", func() {
+			title := "Test Title"
+			target := "https://www.example.com"
+			shareLink := model.SocialTwitter.CreateLink(title, target)
+
+			Convey("Should create a link of the specified type", func() {
+				So(shareLink.Type, ShouldEqual, model.SocialTwitter)
+			})
+
+			Convey("Should indicate the medium's dependency on JavaScript", func() {
+				So(shareLink.RequiresJavaScript, ShouldBeTrue)
+			})
+
+			Convey("Should contain a well formed link", func() {
+				parsedUrl, err := url.Parse(shareLink.Url)
+				So(err, ShouldBeNil)
+				params := parsedUrl.Query()
+
+				Convey("Should create a link with the correct protocol", func() {
+					So(parsedUrl.Scheme, ShouldEqual, "https")
+				})
+
+				Convey("Should create a link with the correct domain", func() {
+					So(parsedUrl.Hostname(), ShouldEqual, "twitter.com")
+				})
+
+				Convey("Should create a link containing the title", func() {
+					So(params.Get("text"), ShouldEqual, title)
+				})
+
+				Convey("Should create a link containing the target", func() {
+					So(params.Get("url"), ShouldEqual, target)
+				})
+			})
+		})
+	})
+}


### PR DESCRIPTION
### What

Creates links for sharing via email and social media.

Adds support for:
- Email
- Facebook
- LinkedIn
- Twitter

Features:
- Media that require JavaScript to be enabled in the user's browser to post are marked accordingly
- All inputs are URL escaped

Example usage:

```go
title := "Test Title"
target := "https://www.example.com"
shareLink := model.SocialEmail.CreateLink(title, target)
fmt.Printf("%+v", shareLink)
```

Example output:
```
{Type:email Url:mailto:?subject=Test+Title&body=Test+Title%0Ahttps%3A%2F%2Fwww.example.com RequiresJavaScript:false}
```

### How to review

Sense check and `make test`

### Who can review

Go developers
