### PR TITLE
Add ONS Design System Table component

### DIFF
--- a/PATTERNS.md
+++ b/PATTERNS.md
@@ -286,3 +286,791 @@ p.BackTo = coreModel.BackTo{
 {{ template "partials/back-to" . }}
 <div>Some more html</div>
 ```
+
+## Table
+
+To instatiate the [Table](https://ons-design-system.netlify.app/components/table/) UI component in your service needs an entry in the mapper and a template. However as there are many variations of this component this will be expanded on in the next section.
+
+- Basic `mapper.go` example:
+
+```go
+p.ExampleTable = coreModel.Table{
+  Caption: "Example caption",
+  TableHeaders: []coreModel.TableHeader{
+    {
+      Value: "Column A",
+    },
+  },
+  TableRows: []coreModel.TableRow{
+    {
+      TableData: []coreModel.TableData{
+        {
+          Value: "Cell A",
+        },
+      },
+    },
+  },
+}
+```
+
+- In the template file within your service, reference the `partials/table.tmpl` file:
+
+```tmpl
+{{ template "partials/table" .ExampleTable }}
+```
+
+### Variations
+
+The Table component supports many variations. These are optional, and can be
+combined:
+
+- "compact"
+- "responsive"
+- "scrollable"
+- "sortable"
+- "row-hover"
+
+All variations are configured through the mapper.
+
+#### Table with footer
+
+```go
+p.ExampleTable = return coreModel.Table{
+  Caption: "A basic table with a footer",
+  TableHeaders: []coreModel.TableHeader{
+    {
+      Value: "Column A",
+    },
+    {
+      Value: "Column B",
+    },
+    {
+      Value: "Column C",
+    },
+  },
+  TableRows: []coreModel.TableRow{
+    {
+      TableData: []coreModel.TableData{
+        {
+          Value: "Cell A1",
+        },
+        {
+          Value: "Cell B1",
+        },
+        {
+          Value: "Cell C1",
+        },
+      },
+    },
+    {
+      TableData: []coreModel.TableData{
+        {
+          Value: "Cell A2",
+        },
+        {
+          Value: "Cell B2",
+        },
+        {
+          Value: "Cell C2",
+        },
+      },
+    },
+  },
+  TableFooters: []coreModel.TableFooter{
+    {
+      Value: "Column summary A",
+    },
+    {
+      Value: "Column summary B",
+    },
+    {
+      Value: "Column summary C",
+    },
+  },
+}
+```
+
+#### Compact table
+
+```go
+p.ExampleTable = coreModel.Table{
+  Variants: []string{"compact", "row-hover"},
+  Caption:  "A compacted table with a large number of columns",
+  TableHeaders: []coreModel.TableHeader{
+    {
+      Value: "Column A",
+    },
+    {
+      Value: "Column B",
+    },
+    {
+      Value: "Column C",
+    },
+    {
+      Value: "Column D",
+    },
+    {
+      Value: "Column E",
+    },
+    {
+      Value: "Column F",
+    },
+  },
+  TableRows: []coreModel.TableRow{
+    {
+      TableData: []coreModel.TableData{
+        {
+          Value: "Cell A1",
+        },
+        {
+          Value: "Cell B1",
+        },
+        {
+          Value: "Cell C1",
+        },
+        {
+          Value: "Cell D1",
+        },
+        {
+          Value: "Cell E1",
+        },
+        {
+          Value: "Cell F1",
+        },
+      },
+    },
+    {
+      TableData: []coreModel.TableData{
+        {
+          Value: "Cell A2",
+        },
+        {
+          Value: "Cell B2",
+        },
+        {
+          Value: "Cell C2",
+        },
+        {
+          Value: "Cell D2",
+        },
+        {
+          Value: "Cell E1",
+        },
+        {
+          Value: "Cell F1",
+        },
+      },
+    },
+  },
+}
+```
+
+#### Numeric table
+
+```go
+p.ExampleTable = coreModel.Table{
+  Caption: "A basic table with numeric values",
+  TableHeaders: []coreModel.TableHeader{
+    {
+      Value: "Country",
+    },
+    {
+      Value:   "Population mid-2020",
+      Numeric: true,
+    },
+    {
+      Value:   "% change 2019 to 2020",
+      Numeric: true,
+    },
+  },
+  TableRows: []coreModel.TableRow{
+    {
+      TableData: []coreModel.TableData{
+        {
+          Value: "England",
+        },
+        {
+          Value:   "67,081,000",
+          Numeric: true,
+        },
+        {
+          Value:   "0.43",
+          Numeric: true,
+        },
+      },
+    },
+    {
+      TableData: []coreModel.TableData{
+        {
+          Value: "Northern Ireland",
+        },
+        {
+          Value:   "1,896,000",
+          Numeric: true,
+        },
+        {
+          Value:   "0.10",
+          Numeric: true,
+        },
+      },
+    },
+    {
+      TableData: []coreModel.TableData{
+        {
+          Value: "Scotland",
+        },
+        {
+          Value:   "5,466,000",
+          Numeric: true,
+        },
+        {
+          Value:   "0.05",
+          Numeric: true,
+        },
+      },
+    },
+    {
+      TableData: []coreModel.TableData{
+        {
+          Value: "Wales",
+        },
+        {
+          Value:   "3,170,000",
+          Numeric: true,
+        },
+        {
+          Value:   "0.53",
+          Numeric: true,
+        },
+      },
+    },
+  },
+}
+```
+
+#### Responsive table
+
+```go
+p.ExampleTable = coreModel.Table{
+  Variants: []string{"responsive"},
+  Caption:  "Responsive table with stacked rows for small viewports",
+  TableHeaders: []coreModel.TableHeader{
+    {
+      Value: "Country",
+    },
+    {
+      Value: "Highest mountain",
+    },
+    {
+      Value:   "Height in metres",
+      Numeric: true,
+    },
+  },
+  TableRows: []coreModel.TableRow{
+    {
+      TableData: []coreModel.TableData{
+        {
+          Value: "Scotland",
+          Data:  "Country",
+        },
+        {
+          Value: "Ben Nevis",
+          Data:  "Highest mountain",
+        },
+        {
+          Value:   "1,345",
+          Data:    "Height",
+          Numeric: true,
+        },
+      },
+    },
+    {
+      TableData: []coreModel.TableData{
+        {
+          Value: "Wales",
+          Data:  "Country",
+        },
+        {
+          Value: "Snowdon",
+          Data:  "Highest mountain",
+        },
+        {
+          Value:   "1,085",
+          Data:    "Height",
+          Numeric: true,
+        },
+      },
+    },
+    {
+      TableData: []coreModel.TableData{
+        {
+          Value: "England",
+          Data:  "Country",
+        },
+        {
+          Value: "Scafell Pike",
+          Data:  "Highest mountain",
+        },
+        {
+          Value:   "978",
+          Data:    "Height",
+          Numeric: true,
+        },
+      },
+    },
+    {
+      TableData: []coreModel.TableData{
+        {
+          Value: "Northern Ireland",
+          Data:  "Country",
+        },
+        {
+          Value: "Slieve Donard",
+          Data:  "Highest mountain",
+        },
+        {
+          Value:   "850",
+          Data:    "Height",
+          Numeric: true,
+        },
+      },
+    },
+  },
+}
+```
+
+#### Scrollable table
+
+```go
+p.ExampleTable = coreModel.Table{
+  Variants:  []string{"scrollable"},
+  Caption:   "Scrollable table",
+  AriaLabel: "There are 7 columns in this table. Some of the table may be off screen. Scroll or drag horizontally to bring into view.",
+  TableHeaders: []coreModel.TableHeader{
+    {
+      Value: "ID",
+    },
+    {
+      Value: "Title",
+    },
+    {
+      Value: "Abbreviation",
+    },
+    {
+      Value: "Legal basis",
+    },
+    {
+      Value: "Frequency",
+    },
+    {
+      Value: "Date",
+    },
+    {
+      Value: "Status",
+    },
+  },
+  TableRows: []coreModel.TableRow{
+    {
+      TableData: []coreModel.TableData{
+        {
+          Value: "023",
+        },
+        {
+          Value: "Monthly Business Survey - Retail Sales Index",
+        },
+        {
+          Value: "RSI",
+        },
+        {
+          Value: "Statistics of Trade Act 1947",
+        },
+        {
+          Value: "Monthly",
+        },
+        {
+          Value: "20 Jan 2018",
+        },
+        {
+          Value: "<span class='ons-status ons-status--success'>Ready</span>",
+        },
+      },
+    },
+    {
+      TableData: []coreModel.TableData{
+        {
+          Value: "112",
+        },
+        {
+          Value: "Annual Inward Foreign Direct Investment Survey",
+        },
+        {
+          Value: "AIFDI",
+        },
+        {
+          Value: "Statistics of Trade Act 1947",
+        },
+        {
+          Value: "Annually",
+        },
+        {
+          Value: "26 Feb 2018",
+        },
+        {
+          Value: "<span class='ons-status ons-status--dead'>Not ready</span>",
+        },
+      },
+    },
+    {
+      TableData: []coreModel.TableData{
+        {
+          Value: "332",
+        },
+        {
+          Value: "Business Register and Employment Survey",
+        },
+        {
+          Value: "BRES",
+        },
+        {
+          Value: "Statistics of Trade Act 1947",
+        },
+        {
+          Value: "Annually",
+        },
+        {
+          Value: "23 Jan 2013",
+        },
+        {
+          Value: "<span class='ons-status ons-status--info'>In progress</span>",
+        },
+      },
+    },
+    {
+      TableData: []coreModel.TableData{
+        {
+          Value: "654",
+        },
+        {
+          Value: "Quartely Survey of Building Materials Sand and Gravel",
+        },
+        {
+          Value: "QBMS",
+        },
+        {
+          Value: "Statistics of Trade Act 1947 - BEIS",
+        },
+        {
+          Value: "Quartely",
+        },
+        {
+          Value: "24 Jan 2015",
+        },
+        {
+          Value: "<span class='ons-status ons-status--error'>Issue</span>",
+        },
+      },
+    },
+    {
+      TableData: []coreModel.TableData{
+        {
+          Value: "765",
+        },
+        {
+          Value: "Monthly Survey of Building Materials Concrete Building Blocks",
+        },
+        {
+          Value: "MSBB",
+        },
+        {
+          Value: "Voluntary",
+        },
+        {
+          Value: "Monthly",
+        },
+        {
+          Value: "25 Jan 2014",
+        },
+        {
+          Value: "<span class='ons-status ons-status--success'>Ready</span>",
+        },
+      },
+    },
+  },
+}
+```
+
+#### Sortable table
+
+```go
+p.ExampleTable = coreModel.Table{
+  Variants: []string{"sortable"},
+  Caption:  "Javascript enhanced sortable table",
+  SortBy:   "Sort by",
+  AriaAsc:  "ascending",
+  AriaDesc: "descending",
+  TableHeaders: []coreModel.TableHeader{
+    {
+      Value: "ID",
+    },
+    {
+      Value: "Title",
+    },
+    {
+      Value: "Abbreviation",
+    },
+    {
+      Value: "Legal basis",
+    },
+    {
+      Value: "Frequency",
+    },
+    {
+      Value: "Date",
+    },
+    {
+      Value: "Status",
+    },
+  },
+  TableRows: []coreModel.TableRow{
+    {
+      TableData: []coreModel.TableData{
+        {
+          Value: "023",
+        },
+        {
+          Value: "Monthly Business Survey - Retail Sales Index",
+        },
+        {
+          Value: "RSI",
+        },
+        {
+          Value: "Statistics of Trade Act 1947",
+        },
+        {
+          Value:    "Monthly",
+          DataSort: "1",
+        },
+        {
+          Value:    "20 Jan 2018",
+          DataSort: "2018-01-20",
+        },
+        {
+          Value:    "<span class='ons-status ons-status--success'>Ready</span>",
+          DataSort: "0",
+        },
+      },
+    },
+    {
+      TableData: []coreModel.TableData{
+        {
+          Value: "112",
+        },
+        {
+          Value: "Annual Inward Foreign Direct Investment Survey",
+        },
+        {
+          Value: "AIFDI",
+        },
+        {
+          Value: "Statistics of Trade Act 1947",
+        },
+        {
+          Value:    "Annually",
+          DataSort: "12",
+        },
+        {
+          Value:    "26 Feb 2018",
+          DataSort: "2018-02-26",
+        },
+        {
+          Value:    "<span class='ons-status ons-status--dead'>Not ready</span>",
+          DataSort: "1",
+        },
+      },
+    },
+    {
+      TableData: []coreModel.TableData{
+        {
+          Value: "332",
+        },
+        {
+          Value: "Business Register and Employment Survey",
+        },
+        {
+          Value: "BRES",
+        },
+        {
+          Value: "Statistics of Trade Act 1947",
+        },
+        {
+          Value:    "Annually",
+          DataSort: "12",
+        },
+        {
+          Value:    "23 Jan 2013",
+          DataSort: "2013-01-23",
+        },
+        {
+          Value:    "<span class='ons-status ons-status--info'>In progress</span>",
+          DataSort: "2",
+        },
+      },
+    },
+    {
+      TableData: []coreModel.TableData{
+        {
+          Value: "654",
+        },
+        {
+          Value: "Quartely Survey of Building Materials Sand and Gravel",
+        },
+        {
+          Value: "QBMS",
+        },
+        {
+          Value: "Statistics of Trade Act 1947 - BEIS",
+        },
+        {
+          Value:    "Quartely",
+          DataSort: "3",
+        },
+        {
+          Value:    "24 Jan 2015",
+          DataSort: "2015-01-24",
+        },
+        {
+          Value:    "<span class='ons-status ons-status--error'>Issue</span>",
+          DataSort: "3",
+        },
+      },
+    },
+    {
+      TableData: []coreModel.TableData{
+        {
+          Value: "765",
+        },
+        {
+          Value: "Monthly Survey of Building Materials Concrete Building Blocks",
+        },
+        {
+          Value: "MSBB",
+        },
+        {
+          Value: "Voluntary",
+        },
+        {
+          Value:    "Monthly",
+          DataSort: "1",
+        },
+        {
+          Value:    "25 Jan 2014",
+          DataSort: "2014-01-25",
+        },
+        {
+          Value:    "<span class='ons-status ons-status--success'>Ready</span>",
+          DataSort: "0",
+        },
+      },
+    },
+  },
+}
+```
+
+### Forms
+
+Forms can be embedded in any data cell.
+
+```go
+linkForm := coreModel.TableForm{
+  Method: "POST",
+  Action: "#",
+  Button: coreModel.TableFormButton{
+    Text:  "Link",
+    Id:    "form-link",
+    Name:  "form-link-name",
+    Value: "form-link-value",
+    Url:   "https://example.com/foo",
+  },
+  HiddenFormFields: []coreModel.TableFormHiddenField{
+    {
+      Name:  "hidden-name-1",
+      Value: "hidden-value-1",
+    },
+    {
+      Name:  "hidden-name-2",
+      Value: "hidden-value-2",
+    },
+  },
+}
+
+buttonForm := coreModel.TableForm{
+  Method: "POST",
+  Action: "#",
+  Button: coreModel.TableFormButton{
+    Text:  "Button",
+    Id:    "form-button-id",
+    Name:  "form-button-name",
+    Value: "form-button-value",
+  },
+  HiddenFormFields: []coreModel.TableFormHiddenField{
+    {
+      Name:  "hidden-name-1",
+      Value: "hidden-value-1",
+    },
+    {
+      Name:  "hidden-name-2",
+      Value: "hidden-value-2",
+    },
+  },
+}
+
+p.ExampleTable = coreModel.Table{
+  Caption: "A basic table with a caption",
+  Id:      "basic-table",
+  TableHeaders: []coreModel.TableHeader{
+    {
+      Value: "Column A",
+    },
+    {
+      Value: "Column B",
+    },
+    {
+      Value: "Column C",
+    },
+  },
+  TableRows: []coreModel.TableRow{
+    {
+      TableData: []coreModel.TableData{
+        {
+          Value: "Cell A1",
+          Name:  "cell-name",
+        },
+        {
+          Value: "Cell B1",
+        },
+        {
+          Value: "Cell C1",
+        },
+      },
+    },
+    {
+      TableData: []coreModel.TableData{
+        {
+          Value: "Cell A2",
+        },
+        {
+          Form: &linkForm,
+        },
+        {
+          Form: &buttonForm,
+        },
+      },
+    },
+  },
+}
+```
+
+### Localisation
+
+All translations live in `assets/locales/core.<language>.toml` and
+are prefixed with `Table`.

--- a/assets/locales/core.cy.toml
+++ b/assets/locales/core.cy.toml
@@ -659,3 +659,8 @@ one = "Tachwedd"
 [TimestampMonthDecember]
 description = "December"
 one = "Rhagfyr"
+
+# Table
+[TableScrollableDefaultAriaLabel]
+description = "Scrollable table"
+one = "Scrollable table"

--- a/assets/locales/core.en.toml
+++ b/assets/locales/core.en.toml
@@ -654,3 +654,8 @@ one = "November"
 [TimestampMonthDecember]
 description = "December"
 one = "December"
+
+# Table
+[TableScrollableDefaultAriaLabel]
+description = "Scrollable table"
+one = "Scrollable table"

--- a/assets/templates/icons/sort-sprite.tmpl
+++ b/assets/templates/icons/sort-sprite.tmpl
@@ -1,0 +1,11 @@
+<svg
+  id="sort-sprite{{ if . }}-{{ . | lower }}{{end}}"
+  class="ons-svg-icon"
+  viewBox="0 0 12 19"
+  xmlns="http://www.w3.org/2000/svg"
+  focusable="false"
+  fill="currentColor"
+>
+  <path class="ons-topTriangle" d="M6 0l6 7.2H0L6 0zm0 18.6l6-7.2H0l6 7.2zm0 3.6l6 7.2H0l6-7.2z"/>
+  <path class="ons-bottomTriangle" d="M6 18.6l6-7.2H0l6 7.2zm0 3.6l6 7.2H0l6-7.2z"/>
+</svg>

--- a/assets/templates/partials/table-form-button.tmpl
+++ b/assets/templates/partials/table-form-button.tmpl
@@ -1,0 +1,24 @@
+{{ if .Url }}
+  <a
+    href="{{ .Url }}"
+    role="button"
+    class="ons-btn ons-btn--link ons-js-submit-btn{{ if .Classes }} {{ .Classes }}{{ end }}"
+    {{ if .Id }}id="{{ .Id }}"{{ end }}
+  >
+    <span class="ons-btn__inner">
+      <span class="ons-btn__text">{{ .Text }}</span>
+    </span>
+  </a>
+{{ else }}
+  <button
+    type="submit"
+    class="ons-btn{{ if .Classes }} {{ .Classes }}{{ end }}"
+    {{ if .Id }}id="{{ .Id }}"{{ end }}
+    {{ if .Value }}value="{{ .Value | safeHTML }}"{{ end }}
+    {{ if .Name }}name="{{ .Name }}"{{ end }}
+  >
+    <span class="ons-btn__inner">
+      <span class="ons-btn__text">{{ .Text }}</span>
+    </span>
+  </button>
+{{ end }}

--- a/assets/templates/partials/table.tmpl
+++ b/assets/templates/partials/table.tmpl
@@ -1,0 +1,97 @@
+{{ if .FuncContainsVariant "scrollable" }}
+<div class="ons-table-scrollable ons-table-scrollable--on">
+  <div
+    class="ons-table-scrollable__content"
+    tabindex="0"
+    role="region"
+    {{ if and .Caption .AriaLabel }}
+      aria-label="{{ .Caption }}. {{ if .AriaLabel }}{{ .AriaLabel }}{{ else }}{{ localise "TableScrollableDefaultAriaLabel" .Language 1 }}{{ end }}"
+    {{ end }}
+  >
+{{ end }}
+    <table
+      {{ if .Id }}id="{{ .Id }}"{{ end }}
+      class="ons-table{{ if .TableClasses }} {{ .TableClasses }}{{ end }}{{ range .Variants }} ons-table--{{ . }}{{ end }}"
+      {{ if and .SortBy (.FuncContainsVariant "sortable") }}
+        data-aria-sort="{{ .SortBy }}"
+        data-aria-asc="{{ .AriaAsc }}"
+        data-aria-desc="{{ .AriaDesc }}"
+      {{ end }}
+    >
+      {{ if .Caption }}
+        <caption class="ons-table__caption{{ if .HideCaption }} ons-u-vh{{ end }}">
+          {{- .Caption -}}
+        </caption>
+      {{ end }}
+      <thead class="ons-table__head">
+        <tr class="ons-table__row">
+          {{ range $th := .TableHeaders }}
+            <th
+              scope="col"
+              class="ons-table__header{{ if $th.ThClasses }} {{ $th.ThClasses }}{{ end }}{{ if $th.Numeric }} ons-table__header--numeric{{ end }}"
+              {{ if $.FuncContainsVariant "sortable" }}
+                aria-sort="{{ if $th.AriaSort }}{{ $th.AriaSort }}{{ else }}none{{ end }}"
+              {{ end }}
+            >
+              <span {{ if $.FuncContainsVariant "sortable" }}class="ons-u-vh"{{ end }}>
+                {{- $th.Value -}}
+              </span>
+              {{ if $.FuncContainsVariant "sortable" }}
+                {{ template "icons/sort-sprite" $th.Value }}
+              {{ end }}
+            </th>
+          {{ end }}
+        </tr>
+      </thead>
+      <tbody class="ons-table__body">
+        {{ range $tr := .TableRows }}
+          <tr
+            class="ons-table__row{{ if $tr.Highlight }} ons-table__row--highlight{{ end }}"
+            {{ if $tr.Name }}name="{{ $tr.Name }}"{{ end }}
+            {{ if $tr.Id }}id="{{ $tr.Id }}"{{ end }}
+          >
+            {{ range $td := $tr.TableData }}
+              <td
+                class="ons-table__cell{{ if $td.TdClasses }} {{ $td.TdClasses }}{{ end }}{{ if $td.Numeric }} ons-table__cell--numeric{{ end }}"
+                {{ if $td.Id }}id="{{ $td.Id }}"{{ end }}
+                {{ if $td.Name }}name="{{ $td.Name }}"{{ end }}
+                {{ if $td.Data }}data-th="{{ $td.Data }}"{{ end }}
+                {{ if $td.DataSort }}data-sort-value="{{ $td.DataSort }}"{{ end }}
+              >
+                {{ if $td.Form }}
+                  <form
+                    action="{{ $td.Form.Action }}"
+                    method="{{ if $td.Form.Method }}{{ $td.Form.Method }}{{ else }}POST{{ end }}"
+                  >
+                    {{ template "partials/table-form-button" $td.Form.Button }}
+                    {{ range $hiddenField := $td.Form.HiddenFormFields }}
+                      <input
+                        type="hidden"
+                        {{ if $hiddenField.Name }}name="{{ $hiddenField.Name }}"{{ end }}
+                        {{ if $hiddenField.Value }}value="{{ $hiddenField.Value }}"{{ end }}
+                      />
+                    {{ end }}
+                  </form>
+                {{ end }}
+                {{ if $td.Value }}
+                  {{ $td.Value | safeHTML }}
+                {{ end }}
+              </td>
+            {{ end }}
+          </tr>
+        {{ end }}
+      </tbody>
+      {{ if .TableFooters }}
+        <tfoot class="ons-table__foot">
+          <tr class="ons-table__row">
+            {{ range $tfoot := .TableFooters }}
+              <td class="ons-table__cell ons-u-fs-s">{{ $tfoot.Value }}</td>
+            {{ end }}
+          </tr>
+        </tfoot>
+      {{ end }}
+    </table>
+{{ if .FuncContainsVariant "scrollable" }}
+  </div>
+</div>
+{{ end }}

--- a/helper/lower.go
+++ b/helper/lower.go
@@ -1,0 +1,7 @@
+package helper
+
+import "strings"
+
+func Lower(s string) string {
+	return strings.ToLower(s)
+}

--- a/helper/lower_test.go
+++ b/helper/lower_test.go
@@ -1,0 +1,28 @@
+package helper_test
+
+import (
+	"testing"
+
+	"github.com/ONSdigital/dp-renderer/helper"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestLower(t *testing.T) {
+	cases := []struct {
+		Description string
+		Input       string
+		Expected    string
+	}{
+		{"'HELLO WORLD' should become 'hello world'", "HELLO WORLD", "hello world"},
+		{"'Hello World' should become 'hello world'", "Hello World", "hello world"},
+		{"'hEllO WoRlD' should become 'hello world'", "hEllO WoRlD", "hello world"},
+		{"'hello world' should become 'hello world'", "hello world", "hello world"},
+	}
+
+	for _, test := range cases {
+		Convey(test.Description, t, func() {
+			got := helper.Lower(test.Input)
+			So(got, ShouldEqual, test.Expected)
+		})
+	}
+}

--- a/helper/registered_functions.go
+++ b/helper/registered_functions.go
@@ -32,4 +32,5 @@ var RegisteredFuncs template.FuncMap = template.FuncMap{
 	"truncateToMaximuCharacters":   TruncateToMaximumCharacters,
 	"trimPrefixedPeriod":           TrimPrefixedPeriod,
 	"intToString":                  IntToString,
+	"lower":                        Lower,
 }

--- a/model/table.go
+++ b/model/table.go
@@ -1,0 +1,84 @@
+package model
+
+// Defines the form button visible in a data cell
+type TableFormButton struct {
+	Text    string `json:"text"`    // Label text, required
+	Id      string `json:"id"`      // HTML id attribute
+	Name    string `json:"name"`    // HTML name attribute
+	Value   string `json:"value"`   // HTML value attribute
+	Url     string `json:"url"`     // Link destination
+	Classes string `json:"classes"` // Additional classes appended to the HTML class attribute
+}
+
+// Defines hidden form input fields
+type TableFormHiddenField struct {
+	Name  string `json:"name"` // HTML input name attribute
+	Value string `json:"vale"` // HTML input value attribute
+}
+
+// TableForm can be placed in data cells to present a TableFormButton
+type TableForm struct {
+	Method           string                 `json:"method"`             // HTML method attribute, defaults to "POST"
+	Action           string                 `json:"action"`             // HTML action attribute, required
+	Button           TableFormButton        `json:"button"`             // Button shown to the user, required
+	HiddenFormFields []TableFormHiddenField `json:"hidden_form_fields"` // Hidden form inputs
+}
+
+// Defines a column footer
+type TableFooter struct {
+	Value string `json:"value"` // Cell content in the footer, required
+}
+
+// TableData defines an individual data cell
+type TableData struct {
+	TdClasses string     `json:"td_classes"` // Additional classes appended to the HTML class attribute
+	Id        string     `json:"id"`         // HTML id attribute
+	Name      string     `json:"name"`       // HTML name attribute
+	Data      string     `json:"data"`       // Required by the responsive variant, sets the data-th attribute for this cell to its matching column header
+	DataSort  string     `json:"data_sort"`  // Required by the sortable variant, sets the numerical order of a table cell in a column
+	Value     string     `json:"value"`      // Cell content
+	Numeric   bool       `json:"numeric"`    // When true, right aligns content for easier comparison of numeric data
+	Form      *TableForm `json:"form"`       // Settings for a form within the cell
+}
+
+// TableHeader defines column headers
+type TableHeader struct {
+	ThClasses string `json:"th_classes"` // Additional classes appended to the HTML class attribute
+	AriaSort  string `json:"aria_sort"`  // Set to “ascending” or “descending” to set the default order of a table column when the page loads when setting variants to “sortable”. Defaults to “none”
+	Value     string `json:"value"`      // Header content
+	Numeric   bool   `json:"numeric"`    // When true, right aligns content for easier comparison of numeric data
+}
+
+// TableRow holds rows of data
+type TableRow struct {
+	TableData []TableData `json:"table_data"` // An array of data cells populating the row, required
+	Id        string      `json:"id"`         // HTML id attribute
+	Name      string      `json:"name"`       // HTML name attribute
+	Highlight bool        `json:"highlight"`  // When true, highlights the row
+}
+
+// Table displays data in a variety of tabular styles that can be combined in Variants
+type Table struct {
+	Variants     []string      `json:"variants"`      // Possible variants: "compact", "responsive", "scrollable", "sortable", and "row-hover"
+	TableClasses string        `json:"table_classes"` // Additional classes appended to the HTML class attribute
+	Id           string        `json:"id"`            // HTML id attribute
+	Caption      string        `json:"caption"`       // Content of the HTML caption
+	HideCaption  bool          `json:"hide_caption"`  // When true, visually hides the caption
+	AriaLabel    string        `json:"aria_label"`    // The ARIA label to be added if ”scrollable” variant set, to inform screen reader users that the table can be scrolled. Defaults to “Scrollable table“.
+	TableHeaders []TableHeader `json:"table_headers"` // An array of column headers, required
+	TableRows    []TableRow    `json:"trs"`           // An array or data rows, required
+	SortBy       string        `json:"sort_by"`       // Required the "sortable" variant, sets the data-aria-sort attribute for the table. Used as a prefix for the aria-label to announce to screen readers when the table is sorted by a column. For example, “Sort by Date, ascending”
+	AriaAsc      string        `json:"aria_asc"`      // Required by "sortable" variant, sets the data-aria-asc attribute for the table. Used to update aria-sort attribute to announce to screen readers how a table is sorted by a column, for example, “Sort by Date, ascending“
+	AriaDesc     string        `json:"aria_desc"`     // Required by "sortable" variant, sets the data-aria-desc attribute for the table. Used to update aria-sort attribute to announce to screen readers how a table is sorted by a column, for example, “Sort by Date, descending“
+	TableFooters []TableFooter `json:"table_footers"` // An array of cells for the footer of each column
+}
+
+// Tests for the presence of a known variant in the options supplied by the user
+func (table Table) FuncContainsVariant(variant string) bool {
+	for _, v := range table.Variants {
+		if v == variant {
+			return true
+		}
+	}
+	return false
+}

--- a/model/table_test.go
+++ b/model/table_test.go
@@ -1,0 +1,47 @@
+package model_test
+
+import (
+	"testing"
+
+	"github.com/ONSdigital/dp-renderer/model"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestTable(t *testing.T) {
+	Convey("FuncContainsVariant", t, func() {
+		Convey("Should detect a variant among a list of one", func() {
+			table := model.Table{
+				Variants: []string{"apple"},
+			}
+			So(table.FuncContainsVariant("apple"), ShouldBeTrue)
+		})
+
+		Convey("Should detect a variant among a list of many", func() {
+			table := model.Table{
+				Variants: []string{"apple", "banana", "cherry"},
+			}
+			So(table.FuncContainsVariant("banana"), ShouldBeTrue)
+		})
+
+		Convey("Should detect a variant missing from an empty list", func() {
+			table := model.Table{
+				Variants: []string{},
+			}
+			So(table.FuncContainsVariant("apple"), ShouldBeFalse)
+		})
+
+		Convey("Should detect a variant missing from a list of one", func() {
+			table := model.Table{
+				Variants: []string{"apple"},
+			}
+			So(table.FuncContainsVariant("apricot"), ShouldBeFalse)
+		})
+
+		Convey("Should detect a variant missing from a list of many", func() {
+			table := model.Table{
+				Variants: []string{"apple", "banana", "cherry"},
+			}
+			So(table.FuncContainsVariant("blueberry"), ShouldBeFalse)
+		})
+	})
+}


### PR DESCRIPTION
### What

Add the [ONS Design System Table](https://ons-design-system.netlify.app/components/table/). This is a full port of the Table template and a partial port of the Button template as used by the Table in a cell's form.

All of the Table variations are supported, and where the type requirements of Go demand it the model deviates from the Nunjucks macro options of the original. In particular:

- Model names have been changed to associate them with the Table and avoid future naming collisions
- Variants is always an array of strings, instead of a choice between a string or an array
- DataSort is a string instead of an integer

### How to review

It looks just like the example on the ONS Design System page, so if it looks sufficiently Go-ish please approve.
I can demo an integration on a local branch of the article controller on request.

### Who can review

Front end / design system / Go devs
