### PR TITLE
Add optional Id to table of contents

### DIFF
--- a/PATTERNS.md
+++ b/PATTERNS.md
@@ -80,6 +80,7 @@ To instatiate the [table-of-contents](https://ons-design-system.netlify.app/comp
 
 ```go
 page.TableOfContents = TableOfContents{
+  Id: "toc",
   AriaLabel: "Table of contents",
   Title: "Contents",
   Sections: map[string]ContentSection{
@@ -98,6 +99,8 @@ page.TableOfContents = TableOfContents{
   }
 }
 ```
+
+The `Id` is optional.
 
 The keys of the Sections map must match the entries in DisplayOrder,
 and these keys are used as the fragment IDs in the anchor tags.

--- a/assets/templates/partials/table-of-contents.tmpl
+++ b/assets/templates/partials/table-of-contents.tmpl
@@ -1,6 +1,10 @@
 {{/* See PATTERNS.md for usage instructions */}}
 
-<aside class="ons-toc-container" role="complementary">
+<aside
+  {{ if .TableOfContents.Id }}id="{{ .TableOfContents.Id }}"{{ end }}
+  class="ons-toc-container"
+  role="complementary"
+>
   <nav
     class="ons-toc"
     aria-label="{{ .TableOfContents.AriaLabel.FuncLocalise .Language }}"

--- a/model/table_of_contents.go
+++ b/model/table_of_contents.go
@@ -12,6 +12,7 @@ type ContentSection struct {
 
 // TableOfContents contains the contents of the page
 type TableOfContents struct {
+	Id           string                    `json:"id"`
 	AriaLabel    Localisation              `json:"aria_label"`
 	Title        Localisation              `json:"title"`
 	Sections     map[string]ContentSection `json:"sections"`


### PR DESCRIPTION
### What

Optionally set the `id` attribute on the Table of Contents component.

Especially useful in combination with the Back To component.

### How to review

Sense check

### Who can review

Anyone
