### PR TITLE
Add styles partial to main template's header section

### DIFF
--- a/assets/templates/main.tmpl
+++ b/assets/templates/main.tmpl
@@ -36,7 +36,7 @@
     {{ else }}
       <link rel="stylesheet" href="{{ .PatternLibraryAssetsPath }}/css/main.css">
     {{ end }}
-    
+
     {{ if .HasJSONLD -}}
       {{ template "partials/json-ld/base" . }}
     {{- end }}
@@ -57,6 +57,8 @@
     {{ end }}
 
     {{ template "partials/gtm-data-layer" . }}
+    
+    {{ partial "styles" }}
     <!-- Google Tag Manager -->
     <script>
       (function (w, d, s, l, i) {


### PR DESCRIPTION
### What

Currently, we are loading out mapboxGL specific styles via javascript within our webpack js bundle. The problem is that this causes the page's styles to load in after the initial styles are loaded from the header. This delay causes the page to flicker on load. Therefore we can split the styles from the main webpack js bundle into a styles css file and load them within a template partial in the main template.

### How to review

Check that the template partial is in the correct position (it should be after any existing styles so we can override existing styles when and if required).

### Who can review

Devs familiar with dp-renderer or go templating.

Describe who worked on the changes, so that other people can review.
Myself & @geoffmrb 
