### PR TITLE
adding release page data tracking to gtm data layer

### DIFF
--- a/assets/templates/partials/gtm-data-layer.tmpl
+++ b/assets/templates/partials/gtm-data-layer.tmpl
@@ -35,6 +35,14 @@ dataLayer = [{
         "numberOfResults": {{.Count}},
         "resultsPage": {{.Pagination.CurrentPage}},
     {{ end }}
+    {{ if eq .Type "ReleasePage" }}
+        "release-status": {{.ReleasePageData.ReleaseStatus}},
+        "release-date": {{.ReleasePageData.ReleaseDate}},
+        "release-time": {{.ReleasePageData.ReleaseTime}},
+        "release-date-status": {{.ReleasePageData.ReleaseDateStatus}},
+        "contact-name": {{.ReleasePageData.ContactName}},
+        "next-release-date": {{.ReleasePageData.NextReleaseDate}},
+    {{ end }}
     {{ if .Type }}
         "contentType": {{ .Type }},
     {{ end }}

--- a/model/page.go
+++ b/model/page.go
@@ -31,6 +31,17 @@ type Page struct {
 	BackTo                           BackTo           `json:"back_to"`
 	SearchNoIndexEnabled             bool             `json:"search_no_index_enabled"`
 	NavigationContent                []NavigationItem `json:"navigation_content"`
+	ReleasePageData                  ReleasePage      `json:"release_page"`
+}
+
+// ReleasePage contains all information needed to render gmt dataLayer for release-page
+type ReleasePage struct {
+	ReleaseStatus     string `json:"release-status"`
+	ReleaseDate       string `json:"release-date"`
+	ReleaseTime       string `json:"release-time"`
+	ReleaseDateStatus string `json:"release-date-status"`
+	ContactName       string `json:"contact-name"`
+	NextReleaseDate   string `json:"next-release-date"`
 }
 
 // NavigationItem contains all information needed to render the navigation bar and submenus


### PR DESCRIPTION
### What
Adding some release calendar page data to page model.  To allow for google tag manager data layer tracking.

### How to review
Just to make sure the structure is correct

### Who can review
FD / BD
