### PR TITLE
Allow Google Tag Manager (GTM) data layer to be directly manipulated prior to container load

### DIFF
--- a/assets/templates/main.tmpl
+++ b/assets/templates/main.tmpl
@@ -57,7 +57,12 @@
     {{ end }}
 
     {{ template "partials/gtm-data-layer" . }}
-    {{ template "partials/gtm-data-layer-controller-additions" . }}
+    {{/*
+      PreGTMJavaScript is intended to make additional data available to GTM
+      `Container Loaded` events by adding data to the `dataLayer` before
+      GTM runs and loads containers a.k.a. tags.
+    */}}
+    {{ template "partials/pre-gtm-javascript" . }}
     {{ partial "styles" }}
     <!-- Google Tag Manager -->
     <script>

--- a/assets/templates/main.tmpl
+++ b/assets/templates/main.tmpl
@@ -10,9 +10,9 @@
       {{- end }}
       - {{ localise "OfficeForNationalStatistics" .Language 1 }}
     </title>
-    
+
     {{ if eq .Metadata.Title "Home" }}
-      <meta name="description" content="{{ localise "HomepageDescription" .Language 1 }}"> 
+      <meta name="description" content="{{ localise "HomepageDescription" .Language 1 }}">
     {{ else }}
       <meta name="description" content="{{ .Metadata.Description }}">
     {{ end }}
@@ -22,11 +22,11 @@
     <meta name="format-detection" content="telephone=no">
     <meta name="theme-color" content="#58595B">
     <meta name="apple-mobile-web-app-status-bar-style" content="#58595B">
-    
+
     {{ if .Metadata.ServiceName }}
       <meta name="ons:service" content="{{ .Metadata.ServiceName }}">
     {{ end }}
-    
+
     {{ if .FeatureFlags.SixteensVersion }}
       {{ if eq .SiteDomain "localhost" }}
         <link rel="stylesheet" href="http://localhost:9000/dist/css/main.css">
@@ -57,7 +57,7 @@
     {{ end }}
 
     {{ template "partials/gtm-data-layer" . }}
-    
+    {{ template "partials/gtm-data-layer-controller-additions" . }}
     {{ partial "styles" }}
     <!-- Google Tag Manager -->
     <script>
@@ -76,7 +76,7 @@
     </script>
     <!-- End Google Tag Manager -->
   </head>
-  
+
   <body class="page-type--{{ .Type }}">
     <script>
       document.body.className = (
@@ -84,7 +84,7 @@
         ? document.body.className + ' js js-enabled'
         : 'js js-enabled');
     </script>
-    
+
     <!-- Google Tag Manager (noscript) -->
     <noscript>
       <iframe
@@ -94,7 +94,7 @@
         style="display:none;visibility:hidden"></iframe>
     </noscript>
     <!-- End Google Tag Manager (noscript) -->
-    
+
     {{ if not .FeatureFlags.SixteensVersion }}
       <div class="ons-page">
         <div class="ons-page__content">
@@ -121,7 +121,7 @@
         <script defer src="/js/app.js"></script>
       {{ end }}
     {{ end }}
-    
+
     {{ partial "scripts" }}
   </body>
 </html>

--- a/assets/templates/partials/gtm-data-layer-controller-additions.tmpl
+++ b/assets/templates/partials/gtm-data-layer-controller-additions.tmpl
@@ -1,0 +1,7 @@
+{{ if ne (len .DataLayerAdditions) 0 }}
+  <script>
+    {{ range $javascript := .DataLayerAdditions }}
+      {{ $javascript }}
+    {{ end }}
+  </script>
+{{ end }}

--- a/assets/templates/partials/gtm-data-layer-controller-additions.tmpl
+++ b/assets/templates/partials/gtm-data-layer-controller-additions.tmpl
@@ -1,7 +1,0 @@
-{{ if ne (len .DataLayerAdditions) 0 }}
-  <script>
-    {{ range $javascript := .DataLayerAdditions }}
-      {{ $javascript }}
-    {{ end }}
-  </script>
-{{ end }}

--- a/assets/templates/partials/pre-gtm-javascript.tmpl
+++ b/assets/templates/partials/pre-gtm-javascript.tmpl
@@ -1,0 +1,5 @@
+{{ range $javascript := .PreGTMJavaScript }}
+  <script>
+    {{ $javascript }}
+  </script>
+{{ end }}

--- a/model/page.go
+++ b/model/page.go
@@ -1,5 +1,7 @@
 package model
 
+import "html/template"
+
 // Page contains data re-used for each page type a Data struct for data specific to the page type
 type Page struct {
 	Count                            int              `json:"count"`
@@ -31,6 +33,7 @@ type Page struct {
 	BackTo                           BackTo           `json:"back_to"`
 	SearchNoIndexEnabled             bool             `json:"search_no_index_enabled"`
 	NavigationContent                []NavigationItem `json:"navigation_content"`
+	DataLayerAdditions               []template.JS    `json:"data_layer_additions"`
 }
 
 // NavigationItem contains all information needed to render the navigation bar and submenus

--- a/model/page.go
+++ b/model/page.go
@@ -33,7 +33,7 @@ type Page struct {
 	BackTo                           BackTo           `json:"back_to"`
 	SearchNoIndexEnabled             bool             `json:"search_no_index_enabled"`
 	NavigationContent                []NavigationItem `json:"navigation_content"`
-	DataLayerAdditions               []template.JS    `json:"data_layer_additions"`
+	PreGTMJavaScript                 []template.JS    `json:"pre_gtm_javascript"`
 }
 
 // NavigationItem contains all information needed to render the navigation bar and submenus


### PR DESCRIPTION
### What

Allows a frontend controller to manipulate the data layer before Google Tag Manager is loaded, and the containers (tags) it manages along with it. Any data added to the data layer at this point will be available to tags via the GTM "Content Loaded" event.

For example, in the mapper of your frontend controller:

```
 page.PreGTMJavaScript = []template.JS(`
  dataLayer.push({
    "something": "interesting",
  });
`)
```

### How to review

Sense check.

### Who can review

Go developers
