### PR TITLE
Feature/thousands separator

### DIFF
--- a/helper/registered_functions.go
+++ b/helper/registered_functions.go
@@ -33,4 +33,5 @@ var RegisteredFuncs template.FuncMap = template.FuncMap{
 	"trimPrefixedPeriod":           TrimPrefixedPeriod,
 	"intToString":                  IntToString,
 	"lower":                        Lower,
+	"thousandsSeparator":           ThousandsSeparator,
 }

--- a/helper/thousand_separator.go
+++ b/helper/thousand_separator.go
@@ -1,0 +1,12 @@
+package helper
+
+import (
+	"golang.org/x/text/language"
+	"golang.org/x/text/message"
+	"golang.org/x/text/number"
+)
+
+func ThousandsSeparator(i int) string {
+	p := message.NewPrinter(language.English)
+	return p.Sprint(number.Decimal(i))
+}

--- a/helper/thousand_separator_test.go
+++ b/helper/thousand_separator_test.go
@@ -1,0 +1,25 @@
+package helper_test
+
+import (
+	"testing"
+
+	"github.com/ONSdigital/dp-renderer/helper"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestThousandsSeparator(t *testing.T) {
+	Convey("Given an integer to separate", t, func() {
+		Convey("When a valid integer is passed", func() {
+			Convey("Then a string of comma separated thousands is returned", func() {
+				So(helper.ThousandsSeparator(1), ShouldEqual, "1")
+				So(helper.ThousandsSeparator(123), ShouldEqual, "123")
+				So(helper.ThousandsSeparator(1234), ShouldEqual, "1,234")
+				So(helper.ThousandsSeparator(12345), ShouldEqual, "12,345")
+				So(helper.ThousandsSeparator(123456), ShouldEqual, "123,456")
+				So(helper.ThousandsSeparator(1234567), ShouldEqual, "1,234,567")
+				So(helper.ThousandsSeparator(1234567890), ShouldEqual, "1,234,567,890")
+				So(helper.ThousandsSeparator(-1234567890), ShouldEqual, "-1,234,567,890")
+			})
+		})
+	})
+}


### PR DESCRIPTION
### What

Added template helper function to convert an `int` into a `string` that has 1000s separated by a comma, as per the [style guide](https://style.ons.gov.uk/category/house-style/numbers/).
(part) ✅ resolves [trello ticket - Display commas to separate thousands in total count displayed to the user](https://trello.com/c/BBxlqgjq/5868-display-commas-to-separate-thousands-in-total-count-displayed-to-the-user)

### How to review

Sense check
Tests pass

### Who can review

Frontend go dev
