### PR TITLE
Feature/allow no indexing on any app

### DIFF
--- a/assets/templates/main.tmpl
+++ b/assets/templates/main.tmpl
@@ -17,12 +17,14 @@
       <meta name="description" content="{{ .Metadata.Description }}">
     {{ end }}
 
-    <meta charset="utf-8"/>
+    <meta charset="utf-8">
     <meta content="width=device-width,initial-scale=1.0,user-scalable=1" name="viewport">
     <meta name="format-detection" content="telephone=no">
     <meta name="theme-color" content="#58595B">
     <meta name="apple-mobile-web-app-status-bar-style" content="#58595B">
-
+     {{ if .SearchNoIndexEnabled }}
+      <meta name="robots" content="noindex">
+    {{ end }}
     {{ if .Metadata.ServiceName }}
       <meta name="ons:service" content="{{ .Metadata.ServiceName }}">
     {{ end }}
@@ -40,17 +42,6 @@
     {{ if .HasJSONLD -}}
       {{ template "partials/json-ld/base" . }}
     {{- end }}
-
-    {{ if eq .Type "search" }}
-
-      {{/* if search a/b testing is at 100% then noindex tag else canonical tag */}}
-      {{ if .SearchNoIndexEnabled }}
-        <meta name="robots" content="noindex">
-      {{ else }}
-        <link rel="canonical" href={{ concatenateStrings "https://www." .SiteDomain "/search?q=" .Data.Query }}>
-      {{ end }}
-
-    {{ end }}
 
     {{ if eq .Metadata.Title "Feedback" }}
       <link rel="canonical" href={{ concatenateStrings "https://www." .SiteDomain "/feedback" }}>

--- a/assets/templates/main.tmpl
+++ b/assets/templates/main.tmpl
@@ -22,7 +22,7 @@
     <meta name="format-detection" content="telephone=no">
     <meta name="theme-color" content="#58595B">
     <meta name="apple-mobile-web-app-status-bar-style" content="#58595B">
-     {{ if .SearchNoIndexEnabled }}
+    {{ if .SearchNoIndexEnabled }}
       <meta name="robots" content="noindex">
     {{ end }}
     {{ if .Metadata.ServiceName }}


### PR DESCRIPTION
### What

- Moved `<meta name="robots" content="noindex">` outside of `search` types so that any app can set the bool `SearchNoIndexEnabled` and benefit from not having pages crawled
- Spoke with @nshumoogum and confirmed that the `canonical` links were no longer needed
- Removed self closing tag as this is [bad practice](https://github.com/validator/validator/wiki/Markup-%C2%BB-Void-elements#trailing-slashes-in-void-element-start-tags-do-not-mark-the-start-tags-as-self-closing) 

### Coming to a PR soon
- Renaming the `SearchNoIndexEnabled` to the more generic `NoIndexEnabled` but this will be part of a `v2` release

### How to review

Sense check

### Who can review

Frontend dev
