### PR TITLE
Revert "remove link to feedback thanks page"

### DIFF
--- a/assets/templates/partials/feedback.tmpl
+++ b/assets/templates/partials/feedback.tmpl
@@ -17,7 +17,7 @@
         <a
           id="feedback-form-yes"
           class="improve-this-page__page-is-useful-button"
-          href=""
+          href="/feedback/thanks"
           aria-label="{{ localise "YesAria" .Language 1 }}"
         >
           {{- localise "Yes" .Language 1 -}}


### PR DESCRIPTION
### What

We have created a `feedback-thanks` template. Users are now redirected to this page at `/feedback/thanks` when JS is turned off. 

### How to review

Turn off JS. Click on the "Yes" journey and be redirected to `/feedback/thanks`

### Who can review

Anyone