### PR TITLE
Census page has slightly different search bar.  

### DIFF
--- a/assets/templates/partials/header.tmpl
+++ b/assets/templates/partials/header.tmpl
@@ -302,8 +302,8 @@
     {{if not .SearchDisabled}}
         <div class="search nav-search--hidden print--hide" id="searchBar">
             <div class="wrapper" role="search">
-                <form class="col-wrap search__form" action="/search">
-                    <label class="search__label col col--md-23 col--lg-24" for="nav-search">{{ localise "SearchKeywordTimeSeriesID" .Language 1 }}</label>
+                <form class="col-wrap search__form" {{if eq .SearchBarFormAction "" }}  action="/search" {{ else }} action="{{ .SearchBarFormAction }}" {{ end }}>
+                    <label class="search__label col col--md-23 col--lg-24" for="nav-search">{{if eq .SearchBarLocaliseKey "" }} {{ localise "SearchKeywordTimeSeriesID" .Language 1 }} {{ else }} {{ localise .SearchBarLocaliseKey .Language 1 }}  {{ end }}</label>
                     <input
                         type="search"
                         autocomplete="off"

--- a/model/page.go
+++ b/model/page.go
@@ -15,6 +15,8 @@ type Page struct {
 	ServiceMessage                   string           `json:"service_message"`
 	Metadata                         Metadata         `json:"metadata"`
 	SearchDisabled                   bool             `json:"search_disabled"`
+	SearchBarFormAction              string           `json:"search_bar_form_action"`
+	SearchBarLocaliseKey             string           `json:"search_bar_localise_key"`
 	SiteDomain                       string           `json:"-"`
 	PatternLibraryAssetsPath         string           `json:"-"`
 	Language                         string           `json:"language"`


### PR DESCRIPTION
### What

This is one method of making it more generic.  Alternative is turn it off in the search-controller handler and build a duplicate there.  This is less code, and probably more reliable

### How to review

Nothing should happen by default.  If you set the data within the model, then we should be able to manipulate the data.  However, the translations do have to exist.

### Who can review

!me
