### PR TITLE
feature/reference jquery directly

### DIFF
--- a/assets/templates/main.tmpl
+++ b/assets/templates/main.tmpl
@@ -114,13 +114,13 @@
       <script type="module" src="{{ .PatternLibraryAssetsPath }}/js/main.js"></script>
       <script nomodule src="{{ .PatternLibraryAssetsPath }}/js/main.es5.js"></script>
     {{ else }}
+      <script defer src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
       {{ if eq .SiteDomain "localhost" }}
         <script defer src="http://localhost:9000/dist/js/main.js"></script>
-        <script defer src="/js/app.js"></script>
       {{ else }}
         <script defer src="https://cdn.ons.gov.uk/sixteens/{{ .FeatureFlags.SixteensVersion }}/js/main.js"></script>
-        <script defer src="/js/app.js"></script>
       {{ end }}
+      <script defer src="/js/app.js"></script>
     {{ end }}
 
     {{ partial "scripts" }}


### PR DESCRIPTION
### What

As part of a bug fix in sixteens (https://github.com/ONSdigital/sixteens/pull/286); we need to change how jQuery loads on our pages; jQuery is now directly referenced from a cdn

**Note** if an app is updated to this version of dp-renderer and not the latest version of sixteens, the user will potentially load jQuery twice but this will enable backward compatibility while apps are updated. 

### How to review

Sense check

### Who can review

Frontend dev
