### PR TITLE
Feature/ab test gtm

### DIFF
--- a/assets/templates/partials/gtm-data-layer.tmpl
+++ b/assets/templates/partials/gtm-data-layer.tmpl
@@ -31,7 +31,6 @@ dataLayer = [{
         "releaseDate": {{dateFormatYYYYMMDD .ReleaseDate}},
     {{end}}
     {{ if eq .Type "search" }}
-        "newSearch": true,
         "numberOfResults": {{.Count}},
         "resultsPage": {{.Pagination.CurrentPage}},
     {{ end }}

--- a/assets/templates/partials/gtm-data-layer.tmpl
+++ b/assets/templates/partials/gtm-data-layer.tmpl
@@ -35,6 +35,9 @@ dataLayer = [{
         "numberOfResults": {{.Count}},
         "resultsPage": {{.Pagination.CurrentPage}},
     {{ end }}
+    {{ if .ABTest.GTMKey }}
+        "abTest": {{ .ABTest.GTMKey }},
+    {{ end }}
     {{ if .Type }}
         "contentType": {{ .Type }},
     {{ end }}

--- a/model/page.go
+++ b/model/page.go
@@ -39,6 +39,12 @@ type Page struct {
 	RemoveGalleryBackground          bool             `json:"remove_gallery_background"`
 	Feedback                         Feedback         `json:"feedback"`
 	Enable500ErrorPageStyling        bool             `json:"enable_500_error_page_styling"` // flag for hiding standard page "furniture" (header, nav, etc.)
+	ABTest
+}
+
+// ABTest contains all information needed for ABTesting - this is separated for expansion in future.
+type ABTest struct {
+	GTMKey string `json:"abtest_gtm_key"` // key for GTM to differentiate test pages.
 }
 
 // NavigationItem contains all information needed to render the navigation bar and submenus


### PR DESCRIPTION
### What

Added more reusable AB test functionality for passing to data layer in discussion with Awen. 

Made ABTest as a struct if further extension is necessary in future.

Have also removed the old ABtest gtm as not extensible and no longer used. 

### How to review

Check seems ok 

Optionally - fire up a controller and pass an ABTest struct to the page model to set a value. This should then appear in the in-line GTM javascript like so:

<img width="526" alt="Screenshot 2024-01-16 at 08 06 40" src="https://github.com/ONSdigital/dp-renderer/assets/48557245/a077a053-68fa-4738-b211-c2efd9766714">

### Who can review

Frontend Go Dev. 