### PR TITLE
Feature/update compact search

### DIFF
--- a/assets/templates/partials/compact-search.tmpl
+++ b/assets/templates/partials/compact-search.tmpl
@@ -1,26 +1,30 @@
 <div class="ons-field">
   <label
-    class="ons-label ons-u-pb-xs ons-u-fw-n"
+    class="ons-label ons-u-fw-n"
     for="{{ .ElementId }}"
   >
     {{- .Label.FuncLocalise .Language -}}
   </label>
-  <div class="ons-compact-search">
+  <span class="ons-grid--flex ons-input_search-button">
     <input
       type="search"
-      class="ons-compact-search__input"
+      class="ons-input ons-input--text ons-input-type__input ons-search__input"
       value="{{ .SearchTerm }}"
       id="{{ .ElementId }}"
       name="{{ .InputName }}"
     >
     <button
       type="submit"
-      class="ons-btn ons-compact-search__btn"
+      class="ons-btn ons-search__btn ons-btn--small"
     >
-      <span class="visuallyhidden">
-        {{ localise "Search" .Language 1 }}
+      <span class="ons-btn__inner">
+        {{ template "icons/search" }}
+        <span class="ons-btn__text ons-u-vh@xxs@s">
+          <span class="ons-u-vh">
+            {{ localise "Search" .Language 1 }}
+          </span>
+        </span>
       </span>
-      {{ template "icons/search" . }}
     </button>
-  </div>
+  </span>
 </div>


### PR DESCRIPTION
### What

- Updating design system css classes for the ~compact~ [search variant](https://service-manual.ons.gov.uk/design-system/components/input#search) 
- There's a small design bug if the frontend service consumes this version of `dp-renderer` and not the (pending) PR in the `dp-design-system` https://github.com/ONSdigital/dp-design-system/pull/203 
**Note** from a [github search](https://github.com/search?q=org%3AONSdigital+partials%2Fcompact-search&type=code) the only repo affected is the `dp-frontend-release-calendar`

### How to review

Sense check
Image review

#### Before
![Screenshot 2024-02-28 at 14 31 30](https://github.com/ONSdigital/dp-design-system/assets/19624419/333d944c-43c9-4bce-beb8-2a1c66e06dab)

#### After (with css change)
![Screenshot 2024-02-28 at 14 30 24](https://github.com/ONSdigital/dp-design-system/assets/19624419/be4b3274-21f0-48a6-a136-be29f13a4606)

#### After (without css change)
![Screenshot 2024-02-28 at 14 30 09](https://github.com/ONSdigital/dp-design-system/assets/19624419/fb7e23a8-7cc0-4f41-8a80-a775448acdf6)

### Who can review

Frontend dev
