### PR TITLE
Update search input class

### DIFF
--- a/assets/templates/partials/compact-search.tmpl
+++ b/assets/templates/partials/compact-search.tmpl
@@ -8,7 +8,7 @@
   <span class="ons-grid--flex ons-input_search-button">
     <input
       type="search"
-      class="ons-input ons-input--text ons-input-type__input ons-search__input"
+      class="ons-input ons-input--block ons-input--text ons-input-type__input ons-search__input"
       value="{{ .SearchTerm }}"
       id="{{ .ElementId }}"
       name="{{ .InputName }}"


### PR DESCRIPTION
### What

On the Data Aggregate pages built by Flax & Teal the leftcol search input is breaking outside the layout for users on tablets eg: iPad currently happening in the devtools device emulator in the Sandbox environment.

I've added `ons-input--block` to the compact-search input, this stops the `min-width` being set.

### How to review

Sense check.
media check.

**Before**
![image](https://github.com/ONSdigital/dp-renderer/assets/110108574/2c435121-ad2c-4a30-83da-c87e7043d527)

**After**
![image](https://github.com/ONSdigital/dp-renderer/assets/110108574/27d5929d-df9f-4bf8-a1bf-806fdb8b65af)

or you can run it locally.

Pull this branch and following these instructions:-
Update go.mod of one of the frontend apps (I used dp-frontend-search-controller) to use local dp-renderer instance i.e. replace github.com/ONSdigital/dp-renderer/v2 => /src/github.com/ONSdigital/dp-renderer

Run app and check it in different media views.


### Who can review

Frontend
