### PR TITLE
Feature/add dual cookie running

### DIFF
--- a/assets/templates/partials/gtm-data-layer.tmpl
+++ b/assets/templates/partials/gtm-data-layer.tmpl
@@ -1,7 +1,7 @@
 <script>
 
-    // getUsageCookieValue reads the cookies_policy cookie and returns the value a user has set for usage, 
-    // or defaults to true to opt_out of usage cookie if no cookie is set, or theres an error getting the value
+    // getUsageCookieValue reads the legacy cookies_policy and ons_cookies_policy to determine the user's usage preference. 
+    // The legacy policy takes precedence over the new policy. When no policy is found, the user is opted out by default.
     function getUsageCookieValue() {
         // TODO: this is the legacy cookie (cookies_policy) handling and will be removed in due course
         var legacyPolicyCookie = document.cookie.match('(^|;) ?cookies_policy=([^;]*)(;|$)');

--- a/assets/templates/partials/gtm-data-layer.tmpl
+++ b/assets/templates/partials/gtm-data-layer.tmpl
@@ -1,14 +1,27 @@
 <script>
 
-// getUsuageCookieValue reads the cookies_policy cookie and returns the value a user has set for usage, 
+// getUsageCookieValue reads the cookies_policy cookie and returns the value a user has set for usage, 
 // or defaults to true to opt_out of usage cookie if no cookie is set, or theres an error getting the value
 function getUsageCookieValue() {
-    var cookiesPolicyCookie = document.cookie.match('(^|;) ?cookies_policy=([^;]*)(;|$)');
-    if (cookiesPolicyCookie) {
-        var decodedCookie = decodeURIComponent(cookiesPolicyCookie[2])
+    // TODO: this is the legacy cookie (cookies_policy) handling and will be removed in due course
+    var legacyPolicyCookie = document.cookie.match('(^|;) ?cookies_policy=([^;]*)(;|$)');
+    if (legacyPolicyCookie) {
+        console.debug('legacy cookies_policy found')
+        var decodedCookie = decodeURIComponent(legacyPolicyCookie[2])
         var cookieValue = JSON.parse(decodedCookie)
+        console.debug('usage is', cookieValue.usage)
         return !cookieValue.usage
     }
+
+    // ons_cookie_policy handler
+    var policyCookie = document.cookie.match(/^(.*)?\s*'usage':true\s*[^;]+(.*)?$/);
+    if (policyCookie) {
+        console.debug('ons_cookie_policy found - opting in')
+        // this needs to be the inverse - if usage is true the returned value is false and vice versa
+        // user is stating whether they are opting out of usage cookie
+        return false
+    }
+    console.debug('no cookie found - opting out')
     return true
 }
 

--- a/assets/templates/partials/gtm-data-layer.tmpl
+++ b/assets/templates/partials/gtm-data-layer.tmpl
@@ -1,51 +1,51 @@
 <script>
 
-// getUsageCookieValue reads the cookies_policy cookie and returns the value a user has set for usage, 
-// or defaults to true to opt_out of usage cookie if no cookie is set, or theres an error getting the value
-function getUsageCookieValue() {
-    // TODO: this is the legacy cookie (cookies_policy) handling and will be removed in due course
-    var legacyPolicyCookie = document.cookie.match('(^|;) ?cookies_policy=([^;]*)(;|$)');
-    if (legacyPolicyCookie) {
-        console.debug('legacy cookies_policy found')
-        var decodedCookie = decodeURIComponent(legacyPolicyCookie[2])
-        var cookieValue = JSON.parse(decodedCookie)
-        console.debug('usage is', cookieValue.usage)
-        return !cookieValue.usage
+    // getUsageCookieValue reads the cookies_policy cookie and returns the value a user has set for usage, 
+    // or defaults to true to opt_out of usage cookie if no cookie is set, or theres an error getting the value
+    function getUsageCookieValue() {
+        // TODO: this is the legacy cookie (cookies_policy) handling and will be removed in due course
+        var legacyPolicyCookie = document.cookie.match('(^|;) ?cookies_policy=([^;]*)(;|$)');
+        if (legacyPolicyCookie) {
+            console.debug('legacy cookies_policy found');
+            var decodedCookie = decodeURIComponent(legacyPolicyCookie[2]);
+            var cookieValue = JSON.parse(decodedCookie);
+            console.debug('usage is', cookieValue.usage);
+            return !cookieValue.usage
+        }
+
+        // ons_cookie_policy handler
+        var policyCookie = document.cookie.match(/^(.*)?\s*'usage':true\s*[^;]+(.*)?$/);
+        if (policyCookie) {
+            console.debug('ons_cookie_policy found - opting in');
+            // this needs to be the inverse - if usage is true the returned value is false and vice versa
+            // user is stating whether they are opting out of usage cookie
+            return false
+        }
+        console.debug('no cookie found - opting out');
+        return true
     }
 
-    // ons_cookie_policy handler
-    var policyCookie = document.cookie.match(/^(.*)?\s*'usage':true\s*[^;]+(.*)?$/);
-    if (policyCookie) {
-        console.debug('ons_cookie_policy found - opting in')
-        // this needs to be the inverse - if usage is true the returned value is false and vice versa
-        // user is stating whether they are opting out of usage cookie
-        return false
+    // unescape html entities
+    function htmlUnescape(str) {
+        return str.replace(/&#x3D;/g, "=");
     }
-    console.debug('no cookie found - opting out')
-    return true
-}
 
-// unescape html entities
-function htmlUnescape(str){
-    return str.replace(/&#x3D;/g, "=");
-}
-
-dataLayer = [{
-    "analyticsOptOut": getUsageCookieValue(),
-    "gtm.whitelist": ["google","hjtc","lcl"],
-    "gtm.blacklist": ["customScripts","sp","adm","awct","k","d","j"],
-    {{if .DatasetTitle }}
-        "contentTitle": htmlUnescape({{.DatasetTitle}}),
-        "filterTitle": htmlUnescape({{.Metadata.Title}}),
-    {{else}}
-        "contentTitle": htmlUnescape({{.Metadata.Title}}),
-    {{end}}
-    {{if .ReleaseDate }}
-        "releaseDate": {{dateFormatYYYYMMDD .ReleaseDate}},
-    {{end}}
+    dataLayer = [{
+        "analyticsOptOut": getUsageCookieValue(),
+        "gtm.whitelist": ["google", "hjtc", "lcl"],
+        "gtm.blacklist": ["customScripts", "sp", "adm", "awct", "k", "d", "j"],
+    {{ if .DatasetTitle }}
+        "contentTitle": htmlUnescape({{ .DatasetTitle }}),
+        "filterTitle": htmlUnescape({{ .Metadata.Title }}),
+    {{ else }}
+        "contentTitle": htmlUnescape({{ .Metadata.Title }}),
+    {{ end }}
+    {{ if .ReleaseDate }}
+        "releaseDate": {{ dateFormatYYYYMMDD .ReleaseDate }},
+    {{ end }}
     {{ if eq .Type "search" }}
-        "numberOfResults": {{.Count}},
-        "resultsPage": {{.Pagination.CurrentPage}},
+        "numberOfResults": {{ .Count }},
+        "resultsPage": {{ .Pagination.CurrentPage }},
     {{ end }}
     {{ if .ABTest.GTMKey }}
         "abTest": {{ .ABTest.GTMKey }},
@@ -56,6 +56,6 @@ dataLayer = [{
     {{ if .DatasetId }}
         "datasetID": {{ .DatasetId }},
     {{ end }}
-}];
+    }];
 
 </script>


### PR DESCRIPTION
### What

[Enabling dual running](https://jira.ons.gov.uk/browse/DIS-2552) of the legacy/current cookie `cookies_policy` and the to be implemented `ons_cookie_policy`. The functionality changed is only concerned with _reading_ the cookie value. The intention is that the legacy cookie takes priority over the 'usage' setting. The regex used for `ons_cookie_policy - usage:true` is the [same as wagtail](https://github.com/ONSdigital/dis-wagtail/blob/9968ad39ed4b1a6f5d9973ecb11b6c785713689c/cms/jinja2/templates/base.html#L113) 
- Formatted code
- Added comments/notes
- Renamed legacy cookie handling to ensure clarity when the [task to remove legacy code](https://jira.ons.gov.uk/browse/DIS-2559) can be progressed 

__NOTE__ This pr will not be merged until the [content on production](https://jira.ons.gov.uk/browse/DIS-2551) is updated to reflect that this is our intention to handle cookies 

![cookies_pretransition drawio](https://github.com/user-attachments/assets/98964882-8bde-48fb-8b87-24d18e48c853)

### How to review

Sense check
To run locally (optional - might be easier for me to demo!!):
- Pull this branch of the `dp-renderer`
- Replace the `dp-renderer` in `go.mod` with your local instance in your favourite go frontend app (I tested with `dp-frontend-search-controller`)
- Run the `dp-design-system` or `sixteens` (depending on your favourite frontend app)
- Port forward to the api-router in sandbox (if required)
- Use an incognito browser window/clear you cookies for localhost
- If you don't have `ons_cookie_policy` set, visit https://nwp-prototype.ons.gov.uk/ 
- Edit the cookie values in dev-tools as appropriate to the test cases below 👇 make sure the domain is `localhost` if running apps on localhost
- Enable console.debug in dev tools
- Check the `dataLayer` to see what `analyticsOptOut` is set to 
![image](https://github.com/user-attachments/assets/b9504a30-35d7-4171-9280-231def433c14)

test | cookie key | usage | opt out
-- | -- | -- | --
1 | cookies_policy | TRUE | FALSE
2 | cookies_policy | FALSE | TRUE
3 | cookies_policy | malformed | TRUE
4 | cookies_policy | n/a | TRUE
5 | ons_cookie_policy | TRUE | FALSE
6 | ons_cookie_policy | FALSE | TRUE
7 | ons_cookie_policy | malformed | TRUE
8 | ons_cookie_policy | n/a | TRUE
9 | no cookies | n/a | TRUE
10 | cookies_policy | FALSE | TRUE
^ | ons_cookie_policy | FALSE | ^ 
11 | cookies_policy | TRUE | FALSE
^ | ons_cookie_policy | TRUE | ^ 
12 | cookies_policy | FALSE | TRUE
^ | ons_cookie_policy | TRUE | ^ 
13 | cookies_policy | TRUE | FALSE
^ | ons_cookie_policy | FALSE | ^
14 | cookies_policy | malformed | TRUE
^ | ons_cookie_policy | TRUE | ^ 
15 | cookies_policy | FALSE | TRUE
^ | ons_cookie_policy | malformed | ^
16 | cookies_policy | TRUE | FALSE
^ | ons_cookie_policy | malformed | ^ 


### Who can review

Frontend dev
