### PR TITLE
Remove feedback api feature flag

### DIFF
--- a/assets/templates/partials/feedback/feedback.tmpl
+++ b/assets/templates/partials/feedback/feedback.tmpl
@@ -54,20 +54,12 @@
           id="feedback-form-container"
           name="feedback-form"
         >
-          {{ if and .FeatureFlags.EnableFeedbackAPI .FeatureFlags.FeedbackAPIURL}}
-          <input
-            type="hidden"
-            name="url"
-            id="feedback-api-enabled"
-            value="true"
-          >
           <input
             type="hidden"
             name="url"
             id="feedback-api-url"
             value="{{.FeatureFlags.FeedbackAPIURL}}"
           >
-          {{ end }}
           <input
             type="hidden"
             name="feedback-form-type"

--- a/model/page.go
+++ b/model/page.go
@@ -62,8 +62,8 @@ type FeatureFlags struct {
 	HideCookieBanner       bool   `json:"hide_cookie_banner"`
 	ONSDesignSystemVersion string `json:"ons_design_system_version"`
 	SixteensVersion        string `json:"legacy_sixteens_version"`
-	EnableFeedbackAPI      bool   `json:"enable_feedback_api"`
-	FeedbackAPIURL         string `json:"feedback_api_url"` // technically not a feature flag, but used exclusivly with one
+	EnableFeedbackAPI      bool   `json:"enable_feedback_api"` // Deprecated: EnableFeedbackAPI should not be used, it will be removed soon
+	FeedbackAPIURL         string `json:"feedback_api_url"`    // technically not a feature flag, but used exclusivly with one
 	IsPublishing           bool   `json:"is_publishing"`
 }
 


### PR DESCRIPTION
### What

Part of 
[Removing](https://jira.ons.gov.uk/browse/DIS-1848) feature flag for feedback api so `feedback-api-url` is always available and picked up by controllers / libraries 

### How to review

- Sense check
- Only removed `EnableFeedbackAPI`

### Who can review

!Me
