### PR TITLE
Fix cookie banner button targetting issue on safari

### DIFF
--- a/assets/templates/partials/banners/cookies.tmpl
+++ b/assets/templates/partials/banners/cookies.tmpl
@@ -10,10 +10,10 @@
                 </div>
                 <div class="cookies-banner__buttons">
                     <div class="nojs--hide cookies-banner__button cookies-banner__button--accept">
-                        <button class="btn btn--full-width btn--primary btn--focus margin-right--2 font-weight-700 font-size--17 text-wrap js-accept-cookies" data-gtm-accept-cookies="true" type="submit" data-action="accept">{{ localise "CookiesBannerAcceptAllAction" .Language 1 }}</button>
+                        <button class="btn btn--full-width btn--primary btn--focus margin-right--2 font-weight-700 font-size--17 text-wrap js-accept-cookies" data-gtm-accept-cookies="true" type="submit" data-action="accept" tabindex="0">{{ localise "CookiesBannerAcceptAllAction" .Language 1 }}</button>
                     </div>
                     <div class="nojs--hide cookies-banner__button cookies-banner__button--reject">
-                        <button class="btn btn--full-width btn--primary btn--focus margin-right--2 font-weight-700 font-size--17 text-wrap js-reject-cookies" data-gtm-accept-cookies="false" type="submit" data-action="reject">{{ localise "CookiesBannerRejectAdditionalAction" .Language 1 }}</button>
+                        <button class="btn btn--full-width btn--primary btn--focus margin-right--2 font-weight-700 font-size--17 text-wrap js-reject-cookies" data-gtm-accept-cookies="false" type="submit" data-action="reject" tabindex="0">{{ localise "CookiesBannerRejectAdditionalAction" .Language 1 }}</button>
                     </div>
                     <div class="cookies-banner__button">
                         <a href="/cookies">{{ localise "CookiesBannerManageSettings" .Language 1 }}</a>


### PR DESCRIPTION
### What

Fixed issue with Safari not allowing focus when elements are unfocusable. 

This has the effect of not setting cookies on Safari as the event target element becomes the body rather than the button. By setting a tabindex of 0, this convinces Safari that this is a focusable element and therefore becomes the event target.

### How to review

Run with dp-frontend-feedback-controller on safari with dp-design-system running. 
Clear cookies
Click 'accept' or 'reject' cookies.

### Who can review

Frontend dev. 