### PR TITLE
feature/generate etags

### DIFF
--- a/model/page.go
+++ b/model/page.go
@@ -18,7 +18,7 @@ type Page struct {
 	Metadata                         Metadata         `json:"metadata"`
 	SearchDisabled                   bool             `json:"search_disabled"`
 	SiteDomain                       string           `json:"-"`
-	PatternLibraryAssetsPath         string           `json:"-"`
+	PatternLibraryAssetsPath         string           `json:"pattern_library_assets_path"`
 	Language                         string           `json:"language"`
 	IncludeAssetsIntegrityAttributes bool             `json:"-"`
 	ReleaseDate                      string           `json:"release_date"`


### PR DESCRIPTION
### What

As part of [work](https://jira.ons.gov.uk/browse/DIS-2451) to generate etags for various content types, in order to generate the etag the mapper json is converted to bytes. When there are changes to the mapper json a new etag will be created. This change means that if the commit hash for the design system is updated, the etag will be regenerated for css/js asset changes aka a good thing 👍 

### How to review

Sense check

### Who can review

!me
